### PR TITLE
Update send_to_AWS() to work with API changes

### DIFF
--- a/obs.py
+++ b/obs.py
@@ -401,9 +401,8 @@ class Observatory:
                     # compress first
                     to_bz2(im_path + name)
                     name = name + '.bz2'
-                aws_req = {"object_name": "raw_data/2019/" + name}
-                site_str = config.site_config['site']
-                aws_resp = g_dev['obs'].api.authenticated_request('POST', site_str +'/upload/', aws_req)
+                aws_req = {"object_name": name}
+                aws_resp = g_dev['obs'].api.authenticated_request('POST', '/upload/', aws_req)
                 with open(im_path + name, 'rb') as f:
                     files = {'file': (im_path + name, f)}
                     print('--> To AWS -->', str(im_path + name))


### PR DESCRIPTION
Path is now api.photonranch.org/api/upload instead of api.photonranch.org/api/{site}/upload.
The object path is now simply the filename instead of {site}/raw_data/2019/{filename}.