### PR TITLE
Feature/institutefastlanequeue

### DIFF
--- a/configs/aro/site_config.py
+++ b/configs/aro/site_config.py
@@ -49,6 +49,7 @@ site_config = {
     'save_to_alt_path' : 'no',
     'archive_path': 'F:/ptr/',       # Where images are kept.
     'archive_age' : -99.9, # Number of days to keep files in the local archive before deletion. Negative means never delete
+    'send_files_at_end_of_night' : 'no', # For low bandwidth sites, do not send up large files until the end of the night. set to 'no' to disable
     'aux_archive_path':  None,
     'wema_is_active':  True,     # True if an agent (ie a wema) is used at a site.   # Wemas are split sites -- at least two CPS's sharing the control.
     'wema_hostname':  'ARO-WEMA',

--- a/configs/eco/site_config.py
+++ b/configs/eco/site_config.py
@@ -42,6 +42,7 @@ site_config = {
     'save_to_alt_path' : 'no',
     'archive_path':  'C:/ptr/',  # Meant to be where /archive/<camera_id> is added by camera.
     'archive_age' : 14.0, # Number of days to keep files in the local archive before deletion. Negative means never delete
+    'send_files_at_end_of_night' : 'no', # For low bandwidth sites, do not send up large files until the end of the night. set to 'no' to disable
     'aux_archive_path':  None, # '//house-computer/saf_archive_2/archive/',  #  Path to auxillary backup disk.
     'wema_is_active':  False,    #True if split computers used at a site.
     'wema_hostname':  [],  #  Prefer the shorter version

--- a/configs/mr2/site_config.py
+++ b/configs/mr2/site_config.py
@@ -28,7 +28,7 @@ COM24  Planewave Mount Axis 2  USB-1 Shared *
 COM25  Planewave Mount Axis 1  USB-1 Shared *
 
 COM26  Ultimate Backplate      USB-6*
-  
+
    COM  PW Mirror Cover
    COM29  PW Dew Heater*
    COM28  Optec Gemini*
@@ -36,7 +36,7 @@ COM26  Ultimate Backplate      USB-6*
 
 COM27  Ultimate Instrument     USB-4*
 
-   COM31  Optec Perseus*        
+   COM31  Optec Perseus*
    Not COM    Apogee Wheel Front*
    Not COM   Apogee Wheel Back*
    COM
@@ -56,7 +56,7 @@ Park 207.3, 5.285.
 #@@@@
 
 
-site_name = 'mrc2'    #NB These must be unique across all of PTR.  
+site_name = 'mrc2'    #NB These must be unique across all of PTR.
 
 site_config = {
     'site': site_name.lower(), #TIM this may no longer be needed.
@@ -75,6 +75,7 @@ site_config = {
     'archive_path':  'Q:/ptr/',
 
     'archive_age' : -99.9, # Number of days to keep files in the local archive before deletion. Negative means never delete
+    'send_files_at_end_of_night' : 'no', # For low bandwidth sites, do not send up large files until the end of the night. set to 'no' to disable
     'aux_archive_path':  None,
     'wema_is_active':  True,          # True if the split computers used at a site.
     'wema_hostname': 'MRC-WMS-ENC',   # Prefer the shorter version
@@ -90,7 +91,7 @@ site_config = {
 
 
     'host_wema_site_name':  'mrc',  #  The umbrella header for obsys in close geographic proximity.
-     
+
     'name': 'Mountain Ranch Camp Observatory 0m6f6.8',
     'location': 'Santa Barbara, California,  USA',
     'airport_code': 'SBA',
@@ -106,7 +107,7 @@ site_config = {
     'mpc_code':  'ZZ23',    #This is made up for now.
     'time_offset':  -7,
     'TZ_database_name':  'America/Los_Angeles',
-    'timezone': 'PDT',      
+    'timezone': 'PDT',
     'latitude': 34.34595969,     #Decimal degrees, North is Positive
     'longitude': -119.6811323955,   #Decimal degrees, West is negative
     'elevation': 317.75,    # meters above sea level
@@ -129,8 +130,8 @@ site_config = {
     'focus_exposure_time': 15, # Exposure time in seconds for exposure image
     'solve_nth_image' : 10, # Only solve every nth image
     'solve_timer' : 5, # Only solve every X minutes
-    'threshold_mount_update' : 10, # only update mount when X arcseconds away 
-    
+    'threshold_mount_update' : 10, # only update mount when X arcseconds away
+
     'defaults': {
         'observing_conditions': 'observing_conditions1',
         'enclosure': 'enclosure1',
@@ -159,7 +160,7 @@ site_config = {
         ],
      'wema_types': [
         'observing_conditions',
-        'enclosure',    
+        'enclosure',
         ],
      'short_status_devices':  [
         # 'observing_conditions',
@@ -174,11 +175,11 @@ site_config = {
         'camera',
         'sequencer',
         ],
-     
+
     'observing_conditions' : {
         'observing_conditions1': {
             'parent': 'site',
-            'ocn_is_specific':  True,  # Indicates some special site code. 
+            'ocn_is_specific':  True,  # Indicates some special site code.
             # Intention it is found in this file.
             'name': 'SRO File',
             'driver': 'Windows.Share',  # Could be redis, ASCOM, ...
@@ -199,7 +200,7 @@ site_config = {
             'name': 'Megawan',
             'hostIP':  '10.15.0.30',
             'driver': 'Windows_share',
-            'shutdown_script':  None,     
+            'shutdown_script':  None,
             'has_lights':  True,
             'controlled_by':  ['mount1', 'mount2'],
             'is_dome': False,
@@ -211,7 +212,7 @@ site_config = {
             'eve_screen_flat_dur': 1.0,   #hours Duration, prior to next.
             'operations_begin':  -1.0,   #  - hours from Sunset
             'eve_cooldown_offset': -.99,   #  - hours beforeSunset
-            'eve_sky_flat_offset':  0.5,   #  - hours beforeSunset 
+            'eve_sky_flat_offset':  0.5,   #  - hours beforeSunset
             'morn_sky_flat_offset':  0.4,   #  + hours after Sunrise
             'morning_close_offset':  0.41,   #  + hours after Sunrise
             'operations_end':  0.42,
@@ -227,7 +228,7 @@ site_config = {
             'driver': 'ASCOM.PWI4.Telescope',  #This picks up signals to the rotator from the mount.
             'startup_script':  None,
             'recover_script':  None,
-            'shutdown_script':  None,  
+            'shutdown_script':  None,
             'alignment': 'Alt-Az',
             'default_zenith_avoid': 7.0,   #degrees floating
             'east_flip_ra_correction': 0.0,
@@ -253,7 +254,7 @@ site_config = {
                 'home_park_azimuth': 195.0,
                 'fixed_screen _altitude': 0.54,
                 'horizon':  15.,    #  Meant to be a circular horizon. Or set to None if below is filled in.
-                'horizon_detail': { 
+                'horizon_detail': {
                       '0': 32,
                       '30': 35,
                       '36.5': 39,
@@ -281,22 +282,22 @@ site_config = {
                       '315': 32,
                       '360': 32,  #  We use a dict because of fragmented azimuth mesurements.
                       },
-                'refraction_on': True, 
-                'model_on': True, 
+                'refraction_on': True,
+                'model_on': True,
                 'rates_on': True,
                 'model': {
-                    'IH': 0, 
-                    'ID': 0., 
+                    'IH': 0,
+                    'ID': 0.,
                     'WH': 0.,
                     'WD': 0.,
-                    'MA': 0., 
+                    'MA': 0.,
                     'ME': 0.,
-                    'CH': 0., 
+                    'CH': 0.,
                     'NP': 0.,
                     'TF': 0.,
-                    'TX': 0., 
+                    'TX': 0.,
                     'HCES': 0.,
-                    'HCEC': 0., 
+                    'HCEC': 0.,
                     'DCES': 0.,
                     'DCEC': 0.,
                     'IA': 0.0,
@@ -326,7 +327,7 @@ site_config = {
             'driver': None,                     #Essentially this device is informational.  It is mostly about the optics.
             'startup_script':  None,
             'recover_script':  None,
-            'shutdown_script':  None,  
+            'shutdown_script':  None,
             'collecting_area':  128039.0,
             'obscuration':  47,
             'aperture': 610,
@@ -347,7 +348,7 @@ site_config = {
                  },
             'camera_name':  'camera_1_1',
             'filter_wheel_name':  'filter_wheel1',
-            
+
             'has_fans':  True,
             'has_cover':  True,
             'settings': {
@@ -386,7 +387,7 @@ site_config = {
 			'com_port':  'COM9',
             'startup_script':  'None',
             'recover_script':  'None',
-            'shutdown_script':  'None' , 
+            'shutdown_script':  'None' ,
             'minimum': -180.,
             'maximum': 360.0,
             'step_size':  0.0001,     #Is this correct?
@@ -403,7 +404,7 @@ site_config = {
             'driver': 'COM6',  #This needs to be a four or 5 character string as in 'COM8' or 'COM22'
             'startup_script':  None,
             'recover_script':  None,
-            'shutdown_script':  None,  
+            'shutdown_script':  None,
             'minimum': 5.0,   #This is the % of light emitted when Screen is on and nominally at 0% bright.
             'saturate': 170,  #Out of 0.0 - 255, this is the last value where the screen is linear with output.
                                 #These values have a minor temperature sensitivity yet to quantify.
@@ -419,7 +420,7 @@ site_config = {
             'driver': 'ASCOM.OptecGemini.Focuser',
             'startup_script':  None,
             'recover_script':  None,
-            'shutdown_script':  None, 
+            'shutdown_script':  None,
             'reference':  6500,    #Nominal at 20C Primary temperature, in microns not steps.
             'ref_temp':   22.5,      #Update when pinning reference  Larger at lower temperatures.
             'coef_c': -0.0,   #negative means focus moves out as Primary gets colder
@@ -459,7 +460,7 @@ site_config = {
     },
 
 
-        
+
     'lamp_box': {
         'lamp_box1': {
             'parent': 'camera_1',  # Parent is camera for the spectrograph
@@ -470,11 +471,11 @@ site_config = {
             'switches': "None"  # A string of switches/lamps the box has for the FITS header. # 'None'; "Off,Mirr,Tung,NeAr" for UVEX
         },
     },
-    
+
 
 
     #Add CWL, BW and DQE to filter and detector specs.   HA3, HA6 for nm or BW.
-    #FW's may need selector-like treatment 
+    #FW's may need selector-like treatment
     'filter_wheel': {
         "filter_wheel1": {
             "parent": "tel1",
@@ -485,7 +486,7 @@ site_config = {
             #"driver": ['ASCOM.Apogee.FilterWheel', 'ASCOM.Apogee2.FilterWheel'],
             'driver': 'Maxim.CCDcamera',  #'startup_script':  None,
             'recover_script':  None,
-            'shutdown_script':  None, 
+            'shutdown_script':  None,
 
             'settings': {
                 'filter_count': '24',
@@ -493,7 +494,7 @@ site_config = {
                 'filter_reference': 1,
                 'default_filter':  'w',
                 'filter_data': [['filter', 'filter_index', 'filter_offset', 'sky_gain', 'screen_gain', 'abbreviation'],
-                                ['air',     [0, 0], -1000, 0.01, [2, 17], 'ai'],   # 0   
+                                ['air',     [0, 0], -1000, 0.01, [2, 17], 'ai'],   # 0
                                 ['Lum',     [1, 0],     0, 0.01, [2, 17], 'w '],   # 20
                                 ['Red',     [0, 4],     0, 0.01, [2, 17], 'r '],  # 21                                ['JV (Grn)',      [0, 3],     0, 0.01, [2, 17], 'V '],   # 9
                                 ['Green',   [0, 3],     0, 0.01, [2, 17], 'V '],   # 22
@@ -533,7 +534,7 @@ site_config = {
     # there can be overlap of camera names.  LCO convention is letter of cam manuf, letter of chip manuf, then 00, 01, 02, ...
     # However this code will treat the camera name/alias as a string of arbitrary length:  "saf_Neyle's favorite_camera" is
     # perfectly valid as an alias.
-    
+
     #Ultimately every camera needs a specific configuration file, and associated with each camera or guider there may be a
     #darslide, filter wheel, and aux_focus.
     #We preseve the idea camera_1 refers to the first camera on the first ota so camera_2 is first camera on OTA 2
@@ -549,7 +550,7 @@ site_config = {
             'driver':  'ASCOM.FLI.Camera',   #  Maxim.CCDCamera',   #"Maxim.CCDCamera",   #'ASCOM.FLI.Kepler.Camera',  #Code must work withall three
             'startup_script':  None,
             'recover_script':  None,
-            'shutdown_script':  None,  
+            'shutdown_script':  None,
             'detector':  'OnSemi 162803',
             'manufacturer':  'FLI -- Finger Lakes Instrumentation',
             'use_file_mode':  False,
@@ -588,7 +589,7 @@ site_config = {
                 'data_sec': ['[25:9600, 1:6388]', '[13:4800, 1:3194]', '[9:3200, 1:2129]', '[7:2400, 1:1597]'],
                 'trim_sec': ['[1:9576, 1:6388]', '[1:4788, 1:3194]', '[1:3192, 1:2129]', '[1:2394, 1:1597]'],
                 'pix_scale': [0.4685, 0.9371, 1.8742],    #  1.4506,  bin-2  2* math.degrees(math.atan(9/3962000))*3600
-                'x_field_deg': 0.5331,  # round(4096*0.468547/3600, 4),   #32_0 X 32 AMIN  3MIN X 0.5 DEG  
+                'x_field_deg': 0.5331,  # round(4096*0.468547/3600, 4),   #32_0 X 32 AMIN  3MIN X 0.5 DEG
                 'y_field_deg': 0.5331,  # round(4096*0.468547/3600, 4),
                 'field_area_sq_amin': 1023,
                 'overscan_x': 0,
@@ -640,7 +641,7 @@ site_config = {
                     'screen_x0':  8.683,
                     },
                 },
-                
+
             },
         },
 
@@ -652,7 +653,7 @@ site_config = {
         #     'driver':  'ASCOM.QHYCCD.Camera',   #"Maxim.CCDCamera",   #'ASCOM.FLI.Kepler.Camera',  #Code must work withall three
         #     'startup_script':  None,
         #     'recover_script':  None,
-        #     'shutdown_script':  None,  
+        #     'shutdown_script':  None,
         #     'detector':  'Sony IMX571',
         #     'manufacturer':  'QHY -- http://QHYCCD.COM',
         #     'use_file_mode':  False,
@@ -660,7 +661,7 @@ site_config = {
         #     'settings': {    #NB Need to add specification for chiller and its control
         #         'temp_setpoint': -10,
         #         'cooler_on': True,
-        #         'darkslide_com': None, 
+        #         'darkslide_com': None,
         #         'x_start':  0,
         #         'y_start':  0,
         #         'x_width':  6252,
@@ -717,7 +718,7 @@ site_config = {
         #     'driver':  'ASCOM.FLI.Camera',   #"Maxim.CCDCamera",   #'ASCOM.FLI.Kepler.Camera',  #Code must work withall three
         #     'startup_script':  None,
         #     'recover_script':  None,
-        #     'shutdown_script':  None,  
+        #     'shutdown_script':  None,
         #     'detector':  'OSemi 162803Sonyn',
         #     'manufacturer':  'ATIK -- Zwo',
         #     'use_file_mode':  False,
@@ -780,7 +781,7 @@ site_config = {
         #     'driver':  'ASCOM.QHYCCD_GUIDER.Camera',   #'OM.FLI.Camera',   #"Maxim.CCDCamera",   #'ASCOM.FLI.Kepler.Camera',  #Code must work withall three
         #     'startup_script':  None,
         #     'recover_script':  None,
-        #     'shutdown_script':  None,  
+        #     'shutdown_script':  None,
         #     'detector':  'Sony',
         #     'manufacturer':  'QHY -- Finger Lakes Instrumentation',
         #     'use_file_mode':  False,
@@ -835,7 +836,7 @@ site_config = {
         #         },
         #     },
         # },
-        
+
         # 'ag_1_4': {
         #     'parent': 'telescope1',
         #     'name': 'ag04',      #Important because this points to a server file structure by that name.
@@ -843,7 +844,7 @@ site_config = {
         #     'driver':  'ASCOM.QHYCCD_CAM2.Camera',   #"Maxim.CCDCamera",   #'ASCOM.FLI.Kepler.Camera',  #Code must work withall three
         #     'startup_script':  None,
         #     'recover_script':  None,
-        #     'shutdown_script':  None,  
+        #     'shutdown_script':  None,
         #     'detector':  'Sony',
         #     'manufacturer':  'QHY --  ',
         #     'use_file_mode':  False,
@@ -922,7 +923,7 @@ site_config = {
             'redis':  '(host=10.15.0.15, port=6379, db=0, decode_responses=True)',
             'startup_script':  None,
             'recover_script':  None,
-            'shutdown_script':  None,  
+            'shutdown_script':  None,
         },
     },
 }  #This brace closes the while configuration dictionary. Match found up top at:  site_config = {
@@ -941,5 +942,3 @@ if __name__ == '__main__':
         print('Strings matched.')
     if site_config == site_unjasoned:
         print('Dictionaries matched.')
-
-

--- a/configs/mrc/site_config.py
+++ b/configs/mrc/site_config.py
@@ -68,6 +68,7 @@ site_config = {
     'archive_path':  'Q:/ptr/',
 
     'archive_age' : -99.9, # Number of days to keep files in the local archive before deletion. Negative means never delete
+    'send_files_at_end_of_night' : 'no', # For low bandwidth sites, do not send up large files until the end of the night. set to 'no' to disable
     'aux_archive_path':  None,
     'wema_is_active':  True,          # True if the split computers used at a site.
     'wema_hostname': 'MRC-WMS-ENC',   # Prefer the shorter version

--- a/configs/sro/site_config.py
+++ b/configs/sro/site_config.py
@@ -46,7 +46,7 @@ site_config = {
     'save_to_alt_path' : 'no',
     'archive_path':  'F:/ptr/',  # Meant to be where /archive/<camera_id> is added by camera.
     'archive_age' : 14.0, # Number of days to keep files in the local archive before deletion. Negative means never delete
-    'send_files_at_end_of_night' : 'yes', # For low bandwidth sites, do not send up large files until the end of the night. set to 'no' to disable
+    'send_files_at_end_of_night' : 'no', # For low bandwidth sites, do not send up large files until the end of the night. set to 'no' to disable
     'aux_archive_path':  None, # '//house-computer/saf_archive_2/archive/',  #  Path to auxillary backup disk.
     'wema_is_active':  False,    #True if split computers used at a site.
     'wema_hostname':  [],  #  Prefer the shorter version
@@ -495,7 +495,7 @@ site_config = {
                 'trim_sec': ['[1:9576, 1:6388]', '[1:4788, 1:3194]', '[1:3192, 1:2129]', '[1:2394, 1:1597]'],
                 'x_pixel':  6,
                 'y_pixel':  6,
-                'pix_scale': [1.103, 2.134, 3.201, 4.268],
+                'pix_scale': [1.104, 2.134, 3.201, 4.268],
 
                 'CameraXSize' : 4556,
                 'CameraYSize' : 3656,

--- a/configs/sro/site_config.py
+++ b/configs/sro/site_config.py
@@ -46,6 +46,7 @@ site_config = {
     'save_to_alt_path' : 'no',
     'archive_path':  'F:/ptr/',  # Meant to be where /archive/<camera_id> is added by camera.
     'archive_age' : 14.0, # Number of days to keep files in the local archive before deletion. Negative means never delete
+    'send_files_at_end_of_night' : 'yes', # For low bandwidth sites, do not send up large files until the end of the night. set to 'no' to disable
     'aux_archive_path':  None, # '//house-computer/saf_archive_2/archive/',  #  Path to auxillary backup disk.
     'wema_is_active':  False,    #True if split computers used at a site.
     'wema_hostname':  [],  #  Prefer the shorter version

--- a/devices/camera.py
+++ b/devices/camera.py
@@ -2570,7 +2570,7 @@ class Camera:
                             hdusmallfits.writeto(
                                 paths["im_path"] + paths["i768sq_name10"] + ".fz"
                             )
-                            if not no_AWS and self.config["camera"][self.name]["settings"]['send_files_at_end_of_night'] == 'no':
+                            if not no_AWS and self.config['send_files_at_end_of_night'] == 'no':
                                 g_dev["cam"].enqueue_for_fastAWS(
                                     1000,
                                     paths["im_path"],
@@ -2622,7 +2622,7 @@ class Camera:
                             saverretries = saverretries + 1
                     del hdufz  # remove file from memory now that we are doing with it
                     # Send this file up to AWS (THIS WILL BE SENT TO BANZAI INSTEAD, SO THIS IS THE INGESTER POSITION)
-                    if not no_AWS and self.config["camera"][self.name]["settings"]['send_files_at_end_of_night'] == 'no':
+                    if not no_AWS and self.config['send_files_at_end_of_night'] == 'no':
                         self.enqueue_for_AWS(
                             26000000, paths["raw_path"], paths["raw_name00"] + ".fz"
                         )

--- a/devices/camera.py
+++ b/devices/camera.py
@@ -2570,7 +2570,7 @@ class Camera:
                             hdusmallfits.writeto(
                                 paths["im_path"] + paths["i768sq_name10"] + ".fz"
                             )
-                            if not no_AWS:
+                            if not no_AWS and self.config["camera"][self.name]["settings"]['send_files_at_end_of_night'] == 'no':
                                 g_dev["cam"].enqueue_for_fastAWS(
                                     1000,
                                     paths["im_path"],
@@ -2622,7 +2622,7 @@ class Camera:
                             saverretries = saverretries + 1
                     del hdufz  # remove file from memory now that we are doing with it
                     # Send this file up to AWS (THIS WILL BE SENT TO BANZAI INSTEAD, SO THIS IS THE INGESTER POSITION)
-                    if not no_AWS:
+                    if not no_AWS and self.config["camera"][self.name]["settings"]['send_files_at_end_of_night'] == 'no':
                         self.enqueue_for_AWS(
                             26000000, paths["raw_path"], paths["raw_name00"] + ".fz"
                         )

--- a/devices/camera.py
+++ b/devices/camera.py
@@ -2346,7 +2346,7 @@ class Camera:
 
                     # This command uploads the text file information at high priority to AWS. No point sending if part of a smartstack
 
-                    self.enqueue_for_AWS(10, im_path, text_name)
+                    self.enqueue_for_fastAWS(10, im_path, text_name)
 
                     # Make a copy of the raw file to hold onto while the flash reductions are happening.
                     # It will be saved once the jpg has been quickly created.
@@ -2571,7 +2571,7 @@ class Camera:
                                 paths["im_path"] + paths["i768sq_name10"] + ".fz"
                             )
                             if not no_AWS:
-                                g_dev["cam"].enqueue_for_AWS(
+                                g_dev["cam"].enqueue_for_fastAWS(
                                     1000,
                                     paths["im_path"],
                                     paths["i768sq_name10"] + ".fz",
@@ -2783,6 +2783,10 @@ class Camera:
     def enqueue_for_AWS(self, priority, im_path, name):
         image = (im_path, name)
         g_dev["obs"].aws_queue.put((priority, image), block=False)
+
+    def enqueue_for_fastAWS(self, priority, im_path, name):
+        image = (im_path, name)
+        g_dev["obs"].fast_queue.put((priority, image), block=False)
 
     def to_reduce(self, to_red):
         g_dev["obs"].reduce_queue.put(to_red, block=False)

--- a/devices/sequencer.py
+++ b/devices/sequencer.py
@@ -1033,10 +1033,15 @@ class Sequencer:
             if not os.path.exists(g_dev["cam"].site_path + "smartstacks"):
                 os.makedirs(g_dev["cam"].site_path + "smartstacks")
 
+
+
+
             # Reopening config and resetting all the things.
             self.astro_events.compute_day_directory()
-            self.astro_events.display_events()
+            self.astro_events.display_events(endofnightoverride='yes')
             g_dev['obs'].astro_events = self.astro_events
+
+
             # sending this up to AWS
             '''
             Send the config to aws.

--- a/obs.py
+++ b/obs.py
@@ -617,6 +617,8 @@ class Observatory:
         the PTR archive database. All other files, including large fpacked
         fits if archive ingestion fails, will upload to a second S3 bucket.
 
+        This is intended to transfer slower files not needed for UI responsiveness
+
         The pri_image is a tuple, smaller first item has priority.
         The second item is also a tuple containing im_path and name.
         """
@@ -675,12 +677,11 @@ class Observatory:
 
     # Note this is a thread!
     def fast_to_aws(self):
-        """Sends queued files to AWS.
+        """Sends small files specifically focussed on UI responsiveness to AWS.
 
-        Large fpacked fits are uploaded using the ocs-ingester, which
-        adds the image to a dedicated S3 bucket along with a record in
-        the PTR archive database. All other files, including large fpacked
-        fits if archive ingestion fails, will upload to a second S3 bucket.
+        This is primarily a queue for files that need to get to the UI fast and
+        skip the queue. This allows small files to be uploaded simultaneously
+        with bigger files being processed by the ordinary queue.
 
         The pri_image is a tuple, smaller first item has priority.
         The second item is also a tuple containing im_path and name.

--- a/obs.py
+++ b/obs.py
@@ -190,6 +190,11 @@ class Observatory:
         self.aws_queue_thread = threading.Thread(target=self.send_to_aws, args=())
         self.aws_queue_thread.start()
 
+        self.fast_queue = queue.PriorityQueue(maxsize=0)
+        self.fast_queue_thread = threading.Thread(target=self.fast_to_aws, args=())
+        self.fast_queue_thread.start()
+
+
         # Set up command_queue for incoming jobs
         self.cmd_queue = queue.Queue(
             maxsize=30
@@ -666,6 +671,71 @@ class Observatory:
             else:
                 time.sleep(0.2)
 
+    # Note this is a thread!
+    def fast_to_aws(self):
+        """Sends queued files to AWS.
+
+        Large fpacked fits are uploaded using the ocs-ingester, which
+        adds the image to a dedicated S3 bucket along with a record in
+        the PTR archive database. All other files, including large fpacked
+        fits if archive ingestion fails, will upload to a second S3 bucket.
+
+        The pri_image is a tuple, smaller first item has priority.
+        The second item is also a tuple containing im_path and name.
+        """
+
+        one_at_a_time = 0
+        # This stopping mechanism allows for threads to close cleanly.
+        while True:
+
+            if (not self.aws_queue.empty()) and one_at_a_time == 0:
+                one_at_a_time = 1
+                pri_image = self.aws_queue.get(block=False)
+                if pri_image is None:
+                    print("Got an empty entry in aws_queue.")
+                    self.aws_queue.task_done()
+                    one_at_a_time = 0
+                    time.sleep(0.2)
+                    continue
+
+                # Here we parse the file, set up and send to AWS
+                filename = pri_image[1][1]
+                filepath = pri_image[1][0] + filename  # Full path to file on disk
+                aws_resp = g_dev["obs"].api.authenticated_request(
+                    "POST", "/upload/", {"object_name": filename})
+                # Only ingest new large fits.fz files to the PTR archive.
+                if self.env_exists == True and filename.endswith("-EX00.fits.fz"):
+                    with open(filepath, "rb") as fileobj:
+                        try:
+                            if not frame_exists(fileobj):
+                                upload_file_and_ingest_to_archive(fileobj)
+                                print(f"--> To PTR ARCHIVE --> {str(filepath)}")
+                            # If ingester fails, send to default S3 bucket.
+                        except:
+                            files = {"file": (filepath, fileobj)}
+                            requests.post(aws_resp["url"], data=aws_resp["fields"], files=files)
+                            print(f"--> To AWS --> {str(filepath)}")
+                # Send all other files to S3.
+                else:
+                    with open(filepath, "rb") as fileobj:
+                        files = {"file": (filepath, fileobj)}
+                        requests.post(aws_resp["url"], data=aws_resp["fields"], files=files)
+                        print(f"--> To AWS --> {str(filepath)}")
+
+                if (
+                    filename[-3:] == "jpg"
+                    or filename[-3:] == "txt"
+                    or ".fits.fz" in filename
+                    or ".token" in filename
+                ):
+                    os.remove(filepath)
+
+                self.aws_queue.task_done()
+                one_at_a_time = 0
+                time.sleep(0.1)
+            else:
+                time.sleep(0.2)
+
     def send_to_user(self, p_log, p_level="INFO"):
         url_log = "https://logs.photonranch.org/logs/newlog"
         body = json.dumps(
@@ -908,7 +978,7 @@ class Observatory:
                                 stretched_data_uint8,
                             )
 
-                            g_dev["cam"].enqueue_for_AWS(
+                            g_dev["cam"].enqueue_for_fastAWS(
                                 100, paths["im_path"], paths["jpeg_name10"]
                             )
 

--- a/obs.py
+++ b/obs.py
@@ -109,6 +109,8 @@ class Observatory:
         else:
             self.site_is_specific = False
 
+
+
         self.last_request = None
         self.stopped = False
         self.status_count = 0
@@ -1032,9 +1034,9 @@ class Observatory:
                     ] and (
                         datetime.datetime.now() - self.last_solve_time
                     ) > datetime.timedelta(
-                        minutes=self.config["solve_timer"] and len(sources) > 30
+                        minutes=self.config["solve_timer"]
                     ):
-                        if smartstackid == "no":
+                        if smartstackid == "no" and len(sources) > 30:
                             try:
                                 solve = platesolve.platesolve(
                                     paths["red_path"] + paths["red_name01"], pixscale

--- a/obs.py
+++ b/obs.py
@@ -690,10 +690,10 @@ class Observatory:
 
             if (not self.aws_queue.empty()) and one_at_a_time == 0:
                 one_at_a_time = 1
-                pri_image = self.aws_queue.get(block=False)
+                pri_image = self.fast_queue.get(block=False)
                 if pri_image is None:
-                    print("Got an empty entry in aws_queue.")
-                    self.aws_queue.task_done()
+                    print("Got an empty entry in fast_queue.")
+                    self.fast_queue.task_done()
                     one_at_a_time = 0
                     time.sleep(0.2)
                     continue
@@ -730,7 +730,7 @@ class Observatory:
                 ):
                     os.remove(filepath)
 
-                self.aws_queue.task_done()
+                self.fast_queue.task_done()
                 one_at_a_time = 0
                 time.sleep(0.1)
             else:

--- a/obs.py
+++ b/obs.py
@@ -1032,7 +1032,7 @@ class Observatory:
                     ] and (
                         datetime.datetime.now() - self.last_solve_time
                     ) > datetime.timedelta(
-                        minutes=self.config["solve_timer"]
+                        minutes=self.config["solve_timer"] and len(sources) > 30
                     ):
                         if smartstackid == "no":
                             try:

--- a/ptr_events.py
+++ b/ptr_events.py
@@ -55,6 +55,7 @@ class Events:
         self.siteRefTemp =  round(float(self.config['reference_ambient']), 2)       #These should be a monthly average data.
         self.siteRefPress =  round(float(self.config['reference_pressure']), 2)
         self.flat_offset = self.config['eve_sky_flat_sunset_offset']    # -35 min for SRO
+
     ###############################
     ###    Internal Methods    ####
     ###############################
@@ -422,7 +423,7 @@ class Events:
         print('Now is:  ', ephem.now(), g_dev['d-a-y'], '\n')
         return DAY_Directory
 
-    def display_events(self):   # Routine above needs to be called first.
+    def display_events(self, endofnightoverride='no'):   # Routine above needs to be called first.
         global dayNow
         # print('Events module loaded at: ', ephem.now(), round((ephem.now()), 4))
         loud = True
@@ -543,30 +544,32 @@ class Events:
         # then needs to be pulled back a day. Primarily because it sometimes does weird things.....
         endNightTime = ephem.Date(sunrise + 120/1440.)
 
-        if ephem.Date(eve_skyFlatBegin) > endNightTime:
-            eve_skyFlatBegin=eve_skyFlatBegin - 24*ephem.hour
-        if ephem.Date(sunset) > endNightTime:
-            sunset=sunset - 24*ephem.hour
-        if ephem.Date(civilDusk) > endNightTime:
-            civilDusk=civilDusk - 24*ephem.hour
-        if ephem.Date(nauticalDusk) > endNightTime:
-            nauticalDusk=nauticalDusk - 24*ephem.hour
-        if ephem.Date(nautDusk_plus_half) > endNightTime:
-            nautDusk_plus_half=nautDusk_plus_half - 24*ephem.hour
-        if ephem.Date(astroDark) > endNightTime:
-            astroDark=astroDark - 24*ephem.hour
-        if ephem.Date(middleNight) > endNightTime:
-            middleNight=middleNight - 24*ephem.hour
-        if ephem.Date(astroEnd) > endNightTime:
-            astroEnd=astroEnd - 24*ephem.hour
-        if ephem.Date(nautDawn_minus_half) > endNightTime:
-            nautDawn_minus_half=nautDawn_minus_half - 24*ephem.hour
-        if ephem.Date(nauticalDawn) > endNightTime:
-            nauticalDawn=nauticalDawn - 24*ephem.hour
-        if ephem.Date(civilDawn) > endNightTime:
-            civilDawn=civilDawn- 24*ephem.hour
-        if ephem.Date(sunrise) > endNightTime:
-            sunrise=sunrise - 24*ephem.hour
+
+        if endofnightoverride == 'no':
+            if ephem.Date(eve_skyFlatBegin) > endNightTime:
+                eve_skyFlatBegin=eve_skyFlatBegin - 24*ephem.hour
+            if ephem.Date(sunset) > endNightTime:
+                sunset=sunset - 24*ephem.hour
+            if ephem.Date(civilDusk) > endNightTime:
+                civilDusk=civilDusk - 24*ephem.hour
+            if ephem.Date(nauticalDusk) > endNightTime:
+                nauticalDusk=nauticalDusk - 24*ephem.hour
+            if ephem.Date(nautDusk_plus_half) > endNightTime:
+                nautDusk_plus_half=nautDusk_plus_half - 24*ephem.hour
+            if ephem.Date(astroDark) > endNightTime:
+                astroDark=astroDark - 24*ephem.hour
+            if ephem.Date(middleNight) > endNightTime:
+                middleNight=middleNight - 24*ephem.hour
+            if ephem.Date(astroEnd) > endNightTime:
+                astroEnd=astroEnd - 24*ephem.hour
+            if ephem.Date(nautDawn_minus_half) > endNightTime:
+                nautDawn_minus_half=nautDawn_minus_half - 24*ephem.hour
+            if ephem.Date(nauticalDawn) > endNightTime:
+                nauticalDawn=nauticalDawn - 24*ephem.hour
+            if ephem.Date(civilDawn) > endNightTime:
+                civilDawn=civilDawn- 24*ephem.hour
+            if ephem.Date(sunrise) > endNightTime:
+                sunrise=sunrise - 24*ephem.hour
 
 
         print('Events module reporting for duty. \n')

--- a/ptr_events.py
+++ b/ptr_events.py
@@ -25,6 +25,8 @@ from math import degrees
 # print('ObsImports:  ', config, '\n\'', config.site_config['site'])
 from global_yard import *
 
+import sys
+
 from astropy.time import Time
 #from pprint import pprint
 
@@ -531,6 +533,42 @@ class Events:
         #     pass
         #eve_skyFlatBegin = sunset +  -32.5/1440  #  NB NB this should come from sro.jscon
         #  NB NB Should add sit time to this report.
+
+
+        eve_skyFlatBegin = sunset +  self.config['eve_sky_flat_sunset_offset']/1440  #  NB NB this should come from config
+
+
+        # The end of the night is when "End Morn Bias Dark" occurs. All timings must end with that
+        # as this is when the night ends and the schedule gets reconfigured. So anything scheduled AFTER
+        # then needs to be pulled back a day. Primarily because it sometimes does weird things.....
+        endNightTime = ephem.Date(sunrise + 120/1440.)
+
+        if ephem.Date(eve_skyFlatBegin) > endNightTime:
+            eve_skyFlatBegin=eve_skyFlatBegin - 24*ephem.hour
+        if ephem.Date(sunset) > endNightTime:
+            sunset=sunset - 24*ephem.hour
+        if ephem.Date(civilDusk) > endNightTime:
+            civilDusk=civilDusk - 24*ephem.hour
+        if ephem.Date(nauticalDusk) > endNightTime:
+            nauticalDusk=nauticalDusk - 24*ephem.hour
+        if ephem.Date(nautDusk_plus_half) > endNightTime:
+            nautDusk_plus_half=nautDusk_plus_half - 24*ephem.hour
+        if ephem.Date(astroDark) > endNightTime:
+            astroDark=astroDark - 24*ephem.hour
+        if ephem.Date(middleNight) > endNightTime:
+            middleNight=middleNight - 24*ephem.hour
+        if ephem.Date(astroEnd) > endNightTime:
+            astroEnd=astroEnd - 24*ephem.hour
+        if ephem.Date(nautDawn_minus_half) > endNightTime:
+            nautDawn_minus_half=nautDawn_minus_half - 24*ephem.hour
+        if ephem.Date(nauticalDawn) > endNightTime:
+            nauticalDawn=nauticalDawn - 24*ephem.hour
+        if ephem.Date(civilDawn) > endNightTime:
+            civilDawn=civilDawn- 24*ephem.hour
+        if ephem.Date(sunrise) > endNightTime:
+            sunrise=sunrise - 24*ephem.hour
+
+
         print('Events module reporting for duty. \n')
         print('Ephem date     :    ', dayNow)
         print("Julian Day     :    ")
@@ -542,19 +580,19 @@ class Events:
         print('Moon phase %   :    ', round(mid_moon_phase, 1), '%\n')
         print("Key events for the evening, presented by the Solar System: \n")
         #if self.config['site'] == 'sro':
-        eve_skyFlatBegin = sunset +  self.config['eve_sky_flat_sunset_offset']/1440  #  NB NB this should come from config
+
         evnt = [('Eve Bias Dark      ', ephem.Date(eve_skyFlatBegin -125/1440)),
                 ('End Eve Bias Dark  ', ephem.Date(eve_skyFlatBegin - 5/1440)),
                 ('Ops Window Start   ', ephem.Date(eve_skyFlatBegin)),  #Enclosure may open.
                 ('Cool Down, Open    ', ephem.Date(eve_skyFlatBegin)),
                 ('Eve Sky Flats      ', ephem.Date(eve_skyFlatBegin)),   #  Nominally -35 for SRO
-                ('Sun Set            ', sunset),
-                ('Civil Dusk         ', civilDusk),
-                ('Naut Dusk          ', nauticalDusk),
+                ('Sun Set            ', ephem.Date(sunset)),
+                ('Civil Dusk         ', ephem.Date(civilDusk)),
+                ('Naut Dusk          ', ephem.Date(nauticalDusk)),
                 ('End Eve Sky Flats  ', ephem.Date(nauticalDusk - 10/1440)),
                 ('Clock & Auto Focus ', ephem.Date(nautDusk_plus_half -12/1440.)),
                 ('Observing Begins   ', ephem.Date(nautDusk_plus_half)),
-                ('Astro Dark         ', astroDark),
+                ('Astro Dark         ', ephem.Date(astroDark)),
                 ('Middle of Night    ', middleNight),
                 ('End Astro Dark     ', astroEnd),
                 ('Observing Ends     ', ephem.Date(nautDawn_minus_half )),
@@ -608,23 +646,45 @@ class Events:
         #             ('Moon Transit       ', next_moontransit),
         #             ('Moon Set           ', next_moonset)]
 
+
+
         #print("No report of post-close events is available yet. \n\n")
         evnt_sort = self._sortTuple(evnt)
         day_dir = self.compute_day_directory()
+
+
+
+
+        # timezone = "  " + self.config['timezone'] + ": "
+        # offset = self.config['time_offset']
+        # for evnt in evnt_sort:
+
+        #     print(evnt[0], 'UTC: ', evnt[1], timezone, ephem.Date(evnt[1] + float(offset)/24.))
+
+        #sys.exit()
+
         #Edit out rise and sets prior to or after operations.
-        while evnt_sort[0][0] != 'Eve Bias Dark      ':
-            evnt_sort.pop(0)
+
+        #while evnt_sort[0][0] != 'Eve Bias Dark      ':
+        #    evnt_sort.pop(0)
         # while evnt_sort[-1][0] != 'Morn Sun >2 deg':  # Ditto, see above.
         #     evnt_sort.pop(-1)
 
-        while evnt_sort[-1][0] in ['Moon Rise          ', 'Moon Transit       ', ]:
-             evnt_sort.pop(-1)
-        evnt_sort
+        #while evnt_sort[-1][0] in ['Moon Rise          ', 'Moon Transit       ', ]:
+        #     evnt_sort.pop(-1)
+        #evnt_sort
         timezone = "  " + self.config['timezone'] + ": "
         offset = self.config['time_offset']
+
         for evnt in evnt_sort:
 
+
             print(evnt[0], 'UTC: ', evnt[1], timezone, ephem.Date(evnt[1] + float(offset)/24.))    # NB Additon of local times would be handy here.
+
+
+
+
+
         event_dict = {}
         for item in evnt_sort:
             event_dict[item[0].strip()]= item[1]


### PR DESCRIPTION
YES, THERE ARE LESS STUPID WAYS OF DOING ALL THESE THINGS, BUT THEY WORK :)

1) This started out as just putting in the fast lane queue. Which was as simple as making a carbon copy of the aws_queue and calling it something else. That is working. This essentially a high-occupancy vehicle lane / transit lane where only texts and jpegs go where they won't get clogged up by slower moving big fits. This should speed up MRC jpegs significantly. I also put a "send files at end of night" in the config, but that is turned off for the moment, but in the future some sluggish sites might need that.

2) In the midst of that, I noticed why the site wasn't properly resetting at the end of the night in terms of setting up the new schedule. At the end of the night, it was setting up the schedule, but for some reason all the times were for the previous night. I updated ptr_events to do everything in Ephem.date and instituted a rather silly but perfectly functional check on the times and to pull them back by a day if they were irrelevant events in the future. It works for the moment, I will clean it up a bit later. This is key to get working unless we want to go and manually restart all the sites every day.

3) There were the usual very small tweaks that get noticed. Noticably skipping platesolving if there are not enough sources in the image. 