### PR TITLE
Improvements to platesolve and focus plots in UI

### DIFF
--- a/devices/camera.py
+++ b/devices/camera.py
@@ -4401,8 +4401,9 @@ class Camera:
                 del jpeg_subprocess
 
                 g_dev['obs'].enqueue_for_fastUI(
-                    self.camera_path + g_dev['day'] +
-                    "/to_AWS/", jpeg_name, exposure_time
+                    self.camera_path + g_dev['day'] + "/to_AWS/",
+                    jpeg_name,
+                    exposure_time
                 )
             else:
                 mainjpegthread_filename='no'

--- a/devices/camera.py
+++ b/devices/camera.py
@@ -4483,7 +4483,26 @@ class Camera:
                             firstframesmartstack = False
                         platesolvethread_filename=self.local_calibration_path + "smartstacks/platesolve" + str(time.time()).replace('.','') + '.pickle'
 
-                        g_dev['obs'].to_platesolve((platesolvethread_filename, 'hdusmallheader', cal_path, cal_name, frame_type, time.time(), self.pixscale, ra_at_time_of_exposure,dec_at_time_of_exposure, firstframesmartstack, useastrometrynet, False, '','reference', exposure_time))
+                        g_dev['obs'].to_platesolve(
+                            (
+                                platesolvethread_filename,
+                                'hdusmallheader',
+                                cal_path,
+                                cal_name,
+                                frame_type,
+                                time.time(),
+                                self.pixscale,
+                                ra_at_time_of_exposure,
+                                dec_at_time_of_exposure,
+                                firstframesmartstack,
+                                useastrometrynet,
+                                False,
+                                '', # filename of jpg
+                                '', # path to jpg directory
+                                'reference',
+                                exposure_time
+                            )
+                        )
 
                     else:
                         platesolvethread_filename='no'
@@ -5150,8 +5169,26 @@ class Camera:
                     del hdu
 
                     g_dev['obs'].platesolve_is_processing =True
-                    #send recast array as uint16 to platesolve
-                    g_dev['obs'].to_platesolve((np.maximum(outputimg, 0).astype(np.uint16), hdusmallheader, cal_path, cal_name, frame_type, time.time(), self.pixscale, ra_at_time_of_exposure,dec_at_time_of_exposure, False, useastrometrynet, True, im_path_r+ g_dev["day"]+ "/to_AWS/"+ jpeg_name, 'image', exposure_time))
+                    g_dev['obs'].to_platesolve(
+                        (
+                            np.maximum(outputimg, 0).astype(np.uint16),
+                            hdusmallheader,
+                            cal_path,
+                            cal_name,
+                            frame_type,
+                            time.time(),
+                            self.pixscale,
+                            ra_at_time_of_exposure,
+                            dec_at_time_of_exposure,
+                            False,
+                            useastrometrynet,
+                            True,
+                            jpeg_name, # filename
+                            f'{im_path_r}{g_dev["day"]}/to_AWS/', #path to jpg directory
+                            'image',
+                            exposure_time
+                        )
+                   )
 
                 # If this is a focus image,
                 # FWHM.

--- a/devices/camera.py
+++ b/devices/camera.py
@@ -4278,8 +4278,8 @@ class Camera:
                     plog("Problem in the smartstack pickle dump")
                     plog(traceback.format_exc())
 
-
-                g_dev['obs'].fast_queue.put((self.camera_path + g_dev['day'] + "/to_AWS/", jpeg_name ,time.time(), exposure_time), block=False)
+                path_to_image_directory = f"{self.camera_path}{g_dev['day']}/to_AWS/"
+                g_dev['obs'].enqueue_for_fastUI(path_to_image_directory, jpeg_name, exposure_time)
 
             else:
                 smartstackthread_filename='no'

--- a/devices/sequencer.py
+++ b/devices/sequencer.py
@@ -5033,7 +5033,7 @@ class Sequencer:
                     thread.daemon = True
                     thread.start()
                     # Fling the jpeg up
-                    g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time)
+                    g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time, info_image_channel=2)
                 else:
                     plog ("Haven't found a starting point yet..... travelling left and right to find a good starting point ")
                     if position_counter & 1:
@@ -5086,7 +5086,7 @@ class Sequencer:
                             thread = threading.Thread(target=self.construct_focus_jpeg_and_save, args=(((x, y, False, copy.deepcopy(g_dev['cam'].current_focus_jpg), copy.deepcopy(im_path + text_name.replace('EX00.txt', 'EX10.jpg')),False,False),)))
                             thread.daemon = True
                             thread.start()
-                            g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time)
+                            g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time, info_image_channel=2)
                             g_dev['foc'].set_initial_best_guess_for_focus()
                             self.total_sequencer_control = False
                             self.focussing=False
@@ -5101,7 +5101,7 @@ class Sequencer:
                             thread.start()
 
                             # Fling the jpeg up
-                            g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time)
+                            g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time, info_image_channel=2)
 
                         elif minimum_index == len(minimumfind)-1 or  minimum_index == len(minimumfind)-2:
 
@@ -5111,7 +5111,7 @@ class Sequencer:
                             thread.daemon = True
                             thread.start()
                             # Fling the jpeg up
-                            g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time)
+                            g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time, info_image_channel=2)
 
 
 
@@ -5126,7 +5126,7 @@ class Sequencer:
                             thread.daemon = True
                             thread.start()
                             # Fling the jpeg up
-                            g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time)
+                            g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time, info_image_channel=2)
 
                         # If right hand side is too low get another dot
                         elif focus_spots[-1][1] < (minimum_value * 1.5):
@@ -5136,7 +5136,7 @@ class Sequencer:
                             thread.daemon = True
                             thread.start()
                             # Fling the jpeg up
-                            g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time)
+                            g_dev['obs'].enqueue_for_fastUI( im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time, info_image_channel=2)
 
 
                         # If the parabola is not centered roughly on the minimum point, then get another dot on
@@ -5184,7 +5184,7 @@ class Sequencer:
                                     thread.daemon = True
                                     thread.start()
                                     # Fling the jpeg up
-                                    g_dev['obs'].enqueue_for_fastUI(im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time)
+                                    g_dev['obs'].enqueue_for_fastUI(im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time, info_image_channel=2)
 
                                 elif minimum_index == len(minimumfind)-1 or  minimum_index == len(minimumfind)-2:
 
@@ -5194,7 +5194,7 @@ class Sequencer:
                                     thread.daemon = True
                                     thread.start()
                                     # Fling the jpeg up
-                                    g_dev['obs'].enqueue_for_fastUI(im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time)
+                                    g_dev['obs'].enqueue_for_fastUI(im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time, info_image_channel=2)
 
                             else:
                                 plog ("focus pos: " + str(fitted_focus_position))
@@ -5203,7 +5203,7 @@ class Sequencer:
                                 thread.daemon = True
                                 thread.start()
                                 # Fling the jpeg up
-                                g_dev['obs'].enqueue_for_fastUI(im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time)
+                                g_dev['obs'].enqueue_for_fastUI(im_path, text_name.replace('EX00.txt', 'EX10.jpg'), g_dev['cam'].current_exposure_time, info_image_channel=2)
 
                                 # Check that the solved minimum focussed position actually fits in between the lowest measured point and
                                 # the two next door measured points.

--- a/obs.py
+++ b/obs.py
@@ -2906,6 +2906,7 @@ class Observatory:
                     useastronometrynet,
                     pointing_exposure,
                     jpeg_filename,
+                    path_to_jpeg, # not including filename
                     image_or_reference,
                     exposure_time,
                 ) = self.platesolve_queue.get(block=False)
@@ -2989,20 +2990,37 @@ class Observatory:
 
                             # yet another pickle debugger.
                             if True:
-                                pickle.dump([hdufocusdata, hduheader, self.local_calibration_path, cal_name, frame_type, time_platesolve_requested,
-                                 pixscale, pointing_ra, pointing_dec, platesolve_crop, False, 1, g_dev['cam'].settings["saturate"], g_dev['cam'].camera_known_readnoise, self.config['minimum_realistic_seeing'],is_osc,useastronometrynet,pointing_exposure, jpeg_filename, target_ra, target_dec], open('subprocesses/testplatesolvepickle','wb'))
+                                pickle.dump(
+                                    [
+                                        hdufocusdata,
+                                        hduheader,
+                                        self.local_calibration_path,
+                                        cal_name,
+                                        frame_type,
+                                        time_platesolve_requested,
+                                        pixscale,
+                                        pointing_ra,
+                                        pointing_dec,
+                                        platesolve_crop,
+                                        False,
+                                        1,
+                                        g_dev['cam'].settings["saturate"],
+                                        g_dev['cam'].camera_known_readnoise,
+                                        self.config['minimum_realistic_seeing'],
+                                        is_osc,
+                                        useastronometrynet,
+                                        pointing_exposure,
+                                        f'{path_to_jpeg}{jpeg_filename}',
+                                        target_ra,
+                                        target_dec
+                                    ],
+                                    open('subprocesses/testplatesolvepickle','wb')
+                                )
 
 
                             #breakpoint()
 
                             try:
-                                # platesolve_subprocess = subprocess.Popen(
-                                #     ["python", "subprocesses/Platesolveprocess.py"],
-                                #     stdin=None,
-                                #     stdout=None,
-                                #     bufsize=0,
-                                # )
-
                                 platesolve_subprocess = subprocess.Popen(
                                     ["python", "subprocesses/Platesolveprocess.py"],
                                     stdin=subprocess.PIPE,
@@ -3012,19 +3030,6 @@ class Observatory:
                             except OSError:
                                 plog(traceback.format_exc())
                                 pass
-
-
-                            # try:
-                            #     platesolve_subprocess = subprocess.Popen(
-                            #         ["python", "subprocesses/Platesolveprocess.py"],
-                            #         stdin=subprocess.PIPE,
-                            #         stdout=None,
-                            #         bufsize=0,
-                            #     )
-                            # except OSError:
-                            #     plog(traceback.format_exc())
-                            #     pass
-
 
                             try:
                                 pickle.dump(
@@ -3047,7 +3052,7 @@ class Observatory:
                                         is_osc,
                                         useastronometrynet,
                                         pointing_exposure,
-                                        jpeg_filename,
+                                        f'{path_to_jpeg}{jpeg_filename}',
                                         target_ra,
                                         target_dec,
                                     ],
@@ -3096,7 +3101,7 @@ class Observatory:
                             if solve == "error":
                                 # send up the image anyway
                                 self.enqueue_for_fastUI(
-                                    "", jpeg_filename, exposure_time
+                                    path_to_jpeg, jpeg_filename, exposure_time
                                 )
 
                                 plog("Planewave solve came back as error")
@@ -3111,7 +3116,7 @@ class Observatory:
 
                             else:
                                 self.enqueue_for_fastUI(
-                                    "", jpeg_filename, exposure_time
+                                    path_to_jpeg, jpeg_filename, exposure_time
                                 )
 
                                 try:
@@ -3136,9 +3141,6 @@ class Observatory:
                                 if g_dev["cam"].pixscale == None:
                                     g_dev["cam"].pixscale = abs(
                                         solved_arcsecperpixel)
-                                # if np.isnan(g_dev["cam"].pixscale):
-                                #     g_dev["cam"].pixscale = abs(
-                                #         solved_arcsecperpixel)
 
                                 if (
                                     (g_dev["cam"].pixscale * 0.9)

--- a/obs.py
+++ b/obs.py
@@ -3684,7 +3684,7 @@ class Observatory:
 
                                 # Save the file as an uncompressed numpy binary
                                 temparray = np.array(
-                                    slow_process[2], dtype=np.unit16)
+                                    slow_process[2], dtype=np.uint16)
                                 tempmedian = bn.nanmedian(temparray)
                                 if tempmedian > 30 and tempmedian < 58000:
                                     np.save(

--- a/obs.py
+++ b/obs.py
@@ -3099,9 +3099,10 @@ class Observatory:
                                 plog("Could not remove platesolve pickle. ")
 
                             if solve == "error":
-                                # send up the image anyway
+                                # send up the platesolve image
+                                info_image_channel = 1 # send as an info image to this channel
                                 self.enqueue_for_fastUI(
-                                    path_to_jpeg, jpeg_filename, exposure_time
+                                    path_to_jpeg, jpeg_filename, exposure_time, info_image_channel
                                 )
 
                                 plog("Planewave solve came back as error")
@@ -3115,8 +3116,10 @@ class Observatory:
                                 self.platesolve_is_processing = False
 
                             else:
+                                # send up the platesolve image
+                                info_image_channel = 1 # send as an info image to this channel
                                 self.enqueue_for_fastUI(
-                                    path_to_jpeg, jpeg_filename, exposure_time
+                                    path_to_jpeg, jpeg_filename, exposure_time, info_image_channel
                                 )
 
                                 try:
@@ -3836,73 +3839,88 @@ class Observatory:
             if not self.fast_queue.empty():
                 pri_image = self.fast_queue.get(block=False)
 
+                # Parse the inputs in the tuple sent to fast_queue
+                try:
+                    (
+                        path_to_file_directory, # doesn't include file itself
+                        filename,
+                        time_submitted,
+                        exposure_time,
+                        info_image_channel
+                    ) = pri_image
+
+                    filepath = f"{path_to_file_directory}{filename}" # Full path to the file on disk
+                except Exception as e:
+                    plog("Error in fast_to_ui: problem parsing the arguments")
+                    plog(e)
+                    plog("This is what was recieved: ", pri_image)
+                    plog("fast_to_ui did not upload an image.")
+                    continue
+
+
                 # Here we parse the file, set up and send to AWS
                 try:
-                    filename = pri_image[1]
-                    # Full path to file on disk
-                    filepath = pri_image[0] + filename
-
                     if filepath == "":
-                        plog(
-                            "found an empty thing in the fast_queue."     #? Why? MTF finding out."
-                        )
-                    else:
-                        try:
-                            timesubmitted = pri_image[2]
-                        except:
-                            plog((traceback.format_exc()))
+                        plog("The fast_queue contained an entry with no path to the image. ") #? Why? MTF finding out.
+                        continue
 
-                        # If the file is there now
-                        if os.path.exists(filepath) and not "EX20" in filename:
-                            # To the extent it has a size
-                            if os.stat(filepath).st_size > 0:
-                                aws_resp = authenticated_request(
-                                    "POST", "/upload/", {"object_name": filename}
-                                )
-                                with open(filepath, "rb") as fileobj:
-                                    files = {"file": (filepath, fileobj)}
-                                    try:
-                                        reqs.post(
-                                            aws_resp["url"],
-                                            data=aws_resp["fields"],
-                                            files=files,
-                                            timeout=10,
+                    # If the file is there now
+                    if os.path.exists(filepath) and not "EX20" in filename:
+                        # To the extent it has a size
+                        if os.stat(filepath).st_size > 0:
+
+                            request_body = {
+                                "object_name": filename,
+                                "s3_directory": "data" # default to sending as a regular image
+                            }
+                            if info_image_channel is not None:
+                                request_body["s3_directory"] = "info-images"
+                                request_body["info_channel"] = info_image_channel
+
+                            aws_resp = authenticated_request("POST", "/upload/", request_body) # this gets the presigned s3 upload url
+                            with open(filepath, "rb") as fileobj:
+                                files = {"file": (filepath, fileobj)}
+                                try:
+                                    reqs.post(
+                                        aws_resp["url"],
+                                        data=aws_resp["fields"],
+                                        files=files,
+                                        timeout=10,
+                                    )
+                                except Exception as e:
+                                    if (
+                                        "timeout" in str(e).lower()
+                                        or "SSLWantWriteError"
+                                        or "RemoteDisconnected" in str(e)
+                                    ):
+                                        plog(
+                                            "Seems to have been a timeout on the file posted: "
+                                            + str(e)
+                                            + "Putting it back in the queue."
                                         )
-                                    except Exception as e:
-                                        if (
-                                            "timeout" in str(e).lower()
-                                            or "SSLWantWriteError"
-                                            or "RemoteDisconnected" in str(e)
-                                        ):
-                                            plog(
-                                                "Seems to have been a timeout on the file posted: "
-                                                + str(e)
-                                                + "Putting it back in the queue."
-                                            )
-                                            plog(filename)
-                                            self.fast_queue.put(
-                                                pri_image, block=False)
-                                        else:
-                                            plog(
-                                                "Fatal connection glitch for a file posted: "
-                                                + str(e)
-                                            )
-                                            plog(files)
-                                            plog((traceback.format_exc()))
-                            else:
-                                plog(
-                                    str(filepath)
-                                    + " is there but has a zero file size so is probably still being written to, putting back in queue."
-                                )
-                                self.fast_queue.put(pri_image, block=False)
-                        # If it has been less than 3 minutes put it back in
-                        elif time.time() - timesubmitted < 1200 + float(pri_image[3]):
-                            self.fast_queue.put(pri_image, block=False)
+                                        plog(filename)
+                                        self.fast_queue.put(pri_image, block=False)
+                                    else:
+                                        plog(
+                                            "Fatal connection glitch for a file posted: "
+                                            + str(e)
+                                        )
+                                        plog(files)
+                                        plog((traceback.format_exc()))
                         else:
                             plog(
                                 str(filepath)
-                                + " seemed to never turn up... not putting back in the queue"
+                                + " is there but has a zero file size so is probably still being written to, putting back in queue."
                             )
+                            self.fast_queue.put(pri_image, block=False)
+                    # If it has been less than 3 minutes put it back in
+                    elif time.time() - time_submitted < 1200 + float(exposure_time):
+                        self.fast_queue.put(pri_image, block=False)
+                    else:
+                        plog(
+                            str(filepath)
+                            + " seemed to never turn up... not putting back in the queue"
+                        )
                 except:
                     plog("something strange in the UI uploader")
                     plog((traceback.format_exc()))
@@ -4352,11 +4370,41 @@ class Observatory:
         image = (im_path, name, time.time())
         self.ptrarchive_queue.put((priority, image), block=False)
 
-    def enqueue_for_fastUI(self, im_path, name, exposure_time):
-        image = (im_path, name)
-        self.fast_queue.put(
-            (image[0], image[1], time.time(), exposure_time), block=False
+    def enqueue_for_fastUI(self, im_path, filename, exposure_time, info_image_channel=None):
+        """ Add an entry to the queue (self.fast_queue) that feeds the quick image upload thread.
+        Entries are added before the file is created. The queue is monitored by the
+        fast_to_ui method which is run as a separate thread. It checks for existence of
+        the files in the queue, and once they exist, it uploads them and removes
+        the corresponding entry from the queue.
+
+        im_path:            string path to the directory where the file to upload is located
+        filename:               filename of the file to upload
+        exposure_time:      exposure duration in seconds (used to know if the exposure has completed yet)
+        info_image-channel: int in [1,2,3] indicating to send to this info image channel
+                            if None, send the image normally (not as an info image)
+        """
+        # Validate the info image channel: must be an int of 1, 2, or 3
+        # If validation fails, try uploading as a regular image
+        if info_image_channel is not None:
+            try:
+                info_image_channel = int(info_image_channel)
+                if not info_image_channel in {1, 2, 3}:
+                    raise Exception()
+            except:
+                plog(f"Error while attempting to upload {filename} as an info image")
+                plog(f"enqueue_for_fatsUI recieved a misformed value for the info image channel")
+                plog(f"Info image channel must be 1, 2, or 3. Recieved <{info_image_channel}> instead.")
+                plog("Falling back to sending as a normal image.")
+                info_image_channel = None
+
+        payload = (
+            im_path,
+            filename,
+            time.time(),
+            exposure_time,
+            info_image_channel
         )
+        self.fast_queue.put(payload, block=False)
 
     def enqueue_for_mediumUI(self, priority, im_path, name):
         image = (im_path, name)

--- a/subprocesses/Platesolveprocess.py
+++ b/subprocesses/Platesolveprocess.py
@@ -202,7 +202,7 @@ minimum_realistic_seeing=input_psolve_info[14]
 is_osc=input_psolve_info[15]
 useastrometrynet=input_psolve_info[16]
 pointing_exposure=input_psolve_info[17]
-jpeg_filename=input_psolve_info[18]
+jpeg_filename_with_full_path=input_psolve_info[18]
 target_ra=input_psolve_info[19]
 target_dec=input_psolve_info[20]
 
@@ -558,8 +558,8 @@ if solve == 'error':
     final_image = final_image.convert('RGB')
 
     try:
-        final_image.save(jpeg_filename.replace('.jpg','temp.jpg'), keep_rgb=True)#, quality=95)
-        os.rename(jpeg_filename.replace('.jpg','temp.jpg'),jpeg_filename)
+        final_image.save(jpeg_filename_with_full_path.replace('.jpg','temp.jpg'), keep_rgb=True)#, quality=95)
+        os.rename(jpeg_filename_with_full_path.replace('.jpg','temp.jpg'),jpeg_filename_with_full_path)
     except:
         print ("problem in saving, likely trying to overwrite an existing file.")
         print(traceback.format_exc())
@@ -675,13 +675,13 @@ if solve != 'error' and pointing_exposure and not pixscale == None:
     # plt.close()
     # pil_image=Image.frombytes('RGB', temp_canvas.get_width_height(),  temp_canvas.tostring_rgb())
 
-    # pil_image.save(jpeg_filename.replace('.jpg','temp.jpg'), keep_rgb=True)#, quality=95)
-    # os.rename(jpeg_filename.replace('.jpg','temp.jpg'),jpeg_filename)
+    # pil_image.save(jpeg_filename_with_full_path.replace('.jpg','temp.jpg'), keep_rgb=True)#, quality=95)
+    # os.rename(jpeg_filename_with_full_path.replace('.jpg','temp.jpg'),jpeg_filename_with_full_path)
 
-    plt.savefig(jpeg_filename.replace('.jpg','matplotlib.png'), dpi=100, bbox_inches='tight', pad_inches=0)
+    plt.savefig(jpeg_filename_with_full_path.replace('.jpg','matplotlib.png'), dpi=100, bbox_inches='tight', pad_inches=0)
 
 
-    im = Image.open(jpeg_filename.replace('.jpg','matplotlib.png'))
+    im = Image.open(jpeg_filename_with_full_path.replace('.jpg','matplotlib.png'))
 
     # Get amount of padding to add
     fraction_of_padding=(im.size[0]/im.size[1])/aspect
@@ -692,19 +692,19 @@ if solve != 'error' and pointing_exposure and not pixscale == None:
     im=im.convert('RGB')
 
     try:
-        im.save(jpeg_filename.replace('.jpg','temp.jpg'), keep_rgb=True)#, quality=95)
-        os.rename(jpeg_filename.replace('.jpg','temp.jpg'),jpeg_filename)
+        im.save(jpeg_filename_with_full_path.replace('.jpg','temp.jpg'), keep_rgb=True)#, quality=95)
+        os.rename(jpeg_filename_with_full_path.replace('.jpg','temp.jpg'),jpeg_filename_with_full_path)
     except:
         print ("tried to save a jpeg when there is already a jpge")
         print(traceback.format_exc())
 
     try:
-        os.remove(jpeg_filename.replace('.jpg','matplotlib.jpg'))
+        os.remove(jpeg_filename_with_full_path.replace('.jpg','matplotlib.jpg'))
     except:
         pass
 
     try:
-        os.remove(jpeg_filename.replace('.jpg','matplotlib.png'))
+        os.remove(jpeg_filename_with_full_path.replace('.jpg','matplotlib.png'))
     except:
         pass
 


### PR DESCRIPTION
This PR does two things. 

First is fix a bug that caused platesolve plots to only appear as thumbnails in the UI. This was caused by sending the path along with the filename to AWS (instead of just the filename) which generated a thumbnail correctly but failed to locate the original image later when the UI asked for it to be displayed. 

The second is the inclusion of a flag that allows fast images to send as info images. Recall that there are 3 distinct channels that info images can be sent to. Each channel has a distinct slot that appears if an image is available, and images sent to different channels will not overwrite each other. This PR assigns platesolve plots to channel 1 and focus plots to channel 2. 

I'm not sure whether these are the types of candidates intended for the info-image functionality requested a while back. One potential downside is that for a given channel, the only image you can see is the latest. So if it's helpful to see a progression of plots for platesolves or focus images, they may be better off in the regular mix. 

Either way, it is easier to send quick images as info images now for whatever types of images are preferred. 

Note: this code should be tested at a site before we merge it, as I can't test it locally. 