### PR TITLE
NightlyScheduleManager - fetch and manage the calendar of observations 

### DIFF
--- a/config_diff.py
+++ b/config_diff.py
@@ -1,0 +1,150 @@
+import os
+import importlib.util
+import argparse
+from itertools import combinations
+
+def dict_diff(dict1, dict2, path=""):
+    """
+    Identify differences in keys between two dictionaries, including nested dictionaries.
+
+    Args:
+        dict1 (dict): First dictionary
+        dict2 (dict): Second dictionary
+        path (str): Current key path (used for recursion)
+
+    Returns:
+        tuple: Two sets containing keys unique to dict1 and dict2 respectively,
+              with nested keys represented as paths from the root
+    """
+    unique_to_dict1 = set()
+    unique_to_dict2 = set()
+
+    # Find keys in dict1 that are not in dict2 or have different types
+    for key in dict1:
+        current_path = f"{path}.{key}" if path else key
+
+        if key not in dict2:
+            unique_to_dict1.add(current_path)
+        elif isinstance(dict1[key], dict) and isinstance(dict2[key], dict):
+            # Recursively check nested dictionaries
+            nested_diff1, nested_diff2 = dict_diff(dict1[key], dict2[key], current_path)
+            unique_to_dict1.update(nested_diff1)
+            unique_to_dict2.update(nested_diff2)
+        elif isinstance(dict1[key], dict) != isinstance(dict2[key], dict):
+            # If one is a dict and the other isn't, mark as different
+            unique_to_dict1.add(current_path)
+            unique_to_dict2.add(current_path)
+
+    # Find keys in dict2 that are not in dict1
+    for key in dict2:
+        current_path = f"{path}.{key}" if path else key
+        if key not in dict1:
+            unique_to_dict2.add(current_path)
+
+    return unique_to_dict1, unique_to_dict2
+
+
+def load_all_site_configs():
+    """
+    Load all site configuration files from configs/<site_name>/obs_config.py
+    and return a dictionary of site_name -> site_config
+    """
+    site_configs = {}
+    configs_dir = os.path.join(os.path.dirname(__file__), 'configs')
+
+    # Get all subdirectories in configs/
+    for site_name in os.listdir(configs_dir):
+        site_dir = os.path.join(configs_dir, site_name)
+
+        # Skip if not a directory or if it's the RETIRED directory
+        if not os.path.isdir(site_dir) or site_name == 'RETIRED':
+            continue
+
+        config_file = os.path.join(site_dir, 'obs_config.py')
+
+        # Skip if obs_config.py doesn't exist
+        if not os.path.isfile(config_file):
+            continue
+
+        try:
+            # Dynamically import the module
+            spec = importlib.util.spec_from_file_location(f"{site_name}_config", config_file)
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+
+            # Extract site_config from the module
+            if hasattr(module, 'site_config'):
+                site_configs[site_name] = module.site_config
+            else:
+                print(f"Warning: {site_name}/obs_config.py exists but doesn't have a site_config variable")
+        except Exception as e:
+            print(f"Error loading {site_name}/obs_config.py: {str(e)}")
+
+    return site_configs
+
+def get_default_site():
+    """
+    Determines the default site based on the hostname file in the parent directory.
+
+    The default site is determined by looking for a file in the parent directory
+    with the pattern 'hostname{site}'. For example, if the file 'hostnametbo2'
+    exists, the default site would be 'tbo2'.
+
+    Returns:
+        str: The default site name, or None if no hostname file is found.
+    """
+    # Get the parent directory path
+    parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    # Look for files matching the hostname pattern
+    hostname_pattern = "hostname"
+    for file in os.listdir(parent_dir):
+        if file.startswith(hostname_pattern):
+            # Extract the site name from the hostname file
+            site = file[len(hostname_pattern):]
+            return site
+
+    # No hostname file found
+    return None
+
+def print_missing_keys(current_site, reference_site, unique_to_current, unique_to_reference):
+    """
+    Print keys that exist in the reference site but are missing from the current site.
+
+    Args:
+        current_site (str): Name of the current site
+        reference_site (str): Name of the reference site
+        unique_to_current (set): Set of keys unique to the current site
+        unique_to_reference (set): Set of keys unique to the reference site
+    """
+    if not unique_to_reference:
+        print(f"\n{current_site} has all keys present in {reference_site}.")
+        return
+
+    print(f"\nKeys in {reference_site} missing from {current_site}:")
+    for key in sorted(unique_to_reference):
+        print(f"  - {key}")
+    print(f"Total: {len(unique_to_reference)} missing keys")
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(description='Compare site configurations')
+    parser.add_argument('-r', '--reference', default='eco1',
+                        help='Reference site to compare against (default: eco1)')
+    args = parser.parse_args()
+
+    all_configs = load_all_site_configs()
+    this_site = get_default_site()
+
+    # Check if the reference site exists
+    if args.reference not in all_configs:
+        print(f"Error: Reference site '{args.reference}' not found")
+        print(f"Available sites: {', '.join(all_configs.keys())}")
+        exit(1)
+
+    current_site_config = all_configs[this_site]
+    reference_site_config = all_configs[args.reference]
+
+    unique_to_current, unique_to_reference = dict_diff(current_site_config, reference_site_config)
+
+    print(f"Comparing {this_site} (current) with {args.reference} (reference)")
+    print_missing_keys(this_site, args.reference, unique_to_current, unique_to_reference)

--- a/configs/aro1/obs_config.py
+++ b/configs/aro1/obs_config.py
@@ -304,6 +304,8 @@ site_config = {
             'focuser': 'focuser'
         }
     },
+    'configdb_telescope': '0m3',
+    'configdb_enclosure': 'roof',
 
     'device_types': [
         'mount',

--- a/configs/eco1/obs_config.py
+++ b/configs/eco1/obs_config.py
@@ -739,7 +739,7 @@ site_config = {
 
                 'do_cosmics' : False,
                 # Simialrly for Salt and Pepper
-                'do_saltandpepper' : True,
+                'do_saltandpepper' : False,
                 # And debanding
                 'do_debanding' : False,
 

--- a/configs/eco1/obs_config.py
+++ b/configs/eco1/obs_config.py
@@ -88,12 +88,12 @@ site_config = {
 
     # The site can fully platesolve each image before it is sent off to s3 or a PIPE
     # If there are spare enough cycles at the site, this saves time for the PIPE
-    # to concentrate on more resource heavy reductions. 
+    # to concentrate on more resource heavy reductions.
     # Also leads to fully platesolved reduced images on the local site computer
     # Usually set this to True
     # if the scope has a decent NUC.... CURRENTLY LEAVE AS IS UNTIL MTF HAS FINISHED TESTING THIS.
     'fully_platesolve_images_at_site_rather_than_pipe' : True,
-    
+
 
     # Setup of folders on local and network drives.
     'client_hostname':  'ECO-0m40',
@@ -230,6 +230,8 @@ site_config = {
             'focuser': 'focuser'
         }
     },
+    'configdb_telescope': '0m43',
+    'configdb_enclosure': 'roof',
 
     'device_types': [
             'mount',
@@ -740,7 +742,7 @@ site_config = {
                 'do_saltandpepper' : True,
                 # And debanding
                 'do_debanding' : False,
-                
+
                 'number_of_bias_to_collect' : 64,
                 'number_of_dark_to_collect' : 64,
                 'number_of_flat_to_collect' : 10,

--- a/configs/eco2/obs_config.py
+++ b/configs/eco2/obs_config.py
@@ -83,7 +83,7 @@ site_config = {
 
     # The site can fully platesolve each image before it is sent off to s3 or a PIPE
     # If there are spare enough cycles at the site, this saves time for the PIPE
-    # to concentrate on more resource heavy reductions. 
+    # to concentrate on more resource heavy reductions.
     # Also leads to fully platesolved reduced images on the local site computer
     # Usually set this to True
     # if the scope has a decent NUC.... CURRENTLY LEAVE AS IS UNTIL MTF HAS FINISHED TESTING THIS.
@@ -226,6 +226,8 @@ site_config = {
             'focuser': 'focuser'
         }
     },
+    'configdb_telescope': '0m28',
+    'configdb_enclosure': 'roof',
 
     'device_types': [
             'mount',     #NB NB WER added this back in 20240329.

--- a/configs/mrc1/obs_config.py
+++ b/configs/mrc1/obs_config.py
@@ -55,6 +55,8 @@ site_config = {
     'owner_alias': ['WER', 'TELOPS'],
     'admin_aliases': ["ANS", "WER", "TELOPS", "TB", "DH", "KVH", "KC"],
 
+    "platesolve_timeout": 60, # Default should be about 45 seconds, but slower computers will take longer
+
     # These are the default values that will be set for the obs
     # on a reboot of obs.py. They are safety checks that
     # can be toggled by an admin in the Observe tab.
@@ -149,6 +151,17 @@ site_config = {
     # These are options to minimise diskspace for calibrations
     'produce_fits_file_for_final_calibrations': True,
     'save_archive_versions_of_final_calibrations' : False,
+
+
+    # The site can fully platesolve each image before it is sent off to s3 or a PIPE
+    # If there are spare enough cycles at the site, this saves time for the PIPE
+    # to concentrate on more resource heavy reductions.
+    # Also leads to fully platesolved reduced images on the local site computer
+    # Usually set this to True
+    # if the scope has a decent NUC.... CURRENTLY LEAVE AS IS UNTIL MTF HAS FINISHED TESTING THIS.
+    'fully_platesolve_images_at_site_rather_than_pipe' : False,
+
+
     # A certain type of naming that sorts filenames by numberid first
     'save_reduced_file_numberid_first' : False,
     # Number of files to send up to the ptrarchive simultaneously.
@@ -263,6 +276,28 @@ site_config = {
         'sequencer',    #NB I think we will add "engineering or telops" to the model >>>>
         'telops',       #   >>>>
     ],
+
+    # The LCO scheduler references a description of this site in configdb
+    # The logic in configdb is organized slightly differently than the PTR
+    # config files (like this one), but they should ultimately represent the
+    # same underlying hardware.
+    # When a PTR obsevatory is running an observation created by the scheduler,
+    # we'll use this to figure out what devices to use to run that observation.
+    # The key is the instrument name from configdb, and the value is a dict of
+    # device names from this config file for each type of device.
+    #
+    # This should only be modified if the configuration in configdb changes.
+    'configdb_instrument_mapping': {
+        'qhy461': {
+            'mount': 'eastpier',
+            'camera': 'camera_1_1',
+            'filter_wheel': 'Dual filter wheel',
+            'rotator': 'rotator',
+            'focuser': 'focuser'
+        }
+    },
+    'configdb_telescope': '0m31',
+    'configdb_enclosure': 'enc1',
 
     'mount': {
         'eastpier': {       # NB There can only be one mount with our new model.  >>>>
@@ -927,7 +962,12 @@ site_config = {
 
 
                 # In the EVA Pipeline, whether to run cosmic ray detection on individual images
-                'do_cosmics': False,
+                'do_cosmics': True,
+                # Simialrly for Salt and Pepper
+                'do_saltandpepper' : True,
+                # And debanding
+                'do_debanding' : False,
+
 
                 # Does this camera have a darkslide, if so, what are the settings?
                 'has_darkslide':  True,

--- a/configs/mrc2/obs_config.py
+++ b/configs/mrc2/obs_config.py
@@ -270,6 +270,8 @@ site_config = {
             'focuser': 'focuser'
         }
     },
+    'configdb_telescope': '0m61',
+    'configdb_enclosure': 'enc1',
 
     'device_types': [
         'mount',

--- a/configs/tbo2/obs_config.py
+++ b/configs/tbo2/obs_config.py
@@ -160,6 +160,8 @@ site_config = {
     'solve_nth_image': 1,  # Only solve every nth image
     'solve_timer': 0.05,  # Only solve every X minutes
     'threshold_mount_update': 45,  # only update mount when X arcseconds away
+    "platesolve_timeout": 60, # Default should be about 45 seconds, but slower computers will take longer
+    'fully_platesolve_images_at_site_rather_than_pipe' : True,
 
 
 

--- a/devices/camera.py
+++ b/devices/camera.py
@@ -1272,6 +1272,7 @@ class Camera:
             self.qhydirect = False
             plog("Simulated camera is connected:  ", self._connect(True))
 
+            self.pixscale = 0.75
             self.imagesize_x = 2400
             self.imagesize_y = 2400
 
@@ -1379,16 +1380,16 @@ class Camera:
         # observations yet.
 
         try:
-            self.pixelscale_shelf = shelve.open(
-                g_dev['obs'].obsid_path + 'ptr_night_shelf/' + 'pixelscale' + self.alias + str(g_dev['obs'].name))
-            try:
-                pixelscale_list = self.pixelscale_shelf['pixelscale_list']
-                self.pixscale = bn.nanmedian(pixelscale_list)
-                plog('1x1 pixel scale: ' + str(self.pixscale))
-            except:
-
-                pixelscale_list=None
-                self.pixscale = None
+            if not self.dummy:
+                self.pixelscale_shelf = shelve.open(
+                    g_dev['obs'].obsid_path + 'ptr_night_shelf/' + 'pixelscale' + self.alias + str(g_dev['obs'].name))
+                try:
+                    pixelscale_list = self.pixelscale_shelf['pixelscale_list']
+                    self.pixscale = bn.nanmedian(pixelscale_list)
+                    plog('1x1 pixel scale: ' + str(self.pixscale))
+                except:
+                    pixelscale_list=None
+                    self.pixscale = None
 
 
             # self.pixelscale_shelf.close()
@@ -1398,25 +1399,22 @@ class Camera:
             # else:
             #     self.pixscale = None   #Yes a hack
         except:
-            if self.dummy:
-                self.pixscale=0.75
-            else:
-                plog("ALERT: PIXELSCALE SHELF CORRUPTED. WIPING AND STARTING AGAIN")
-                self.pixscale = None
-                plog(traceback.format_exc())
-                try:
-                    if os.path.exists(g_dev['obs'].obsid_path + 'ptr_night_shelf/' + 'pixelscale' + self.alias + str(g_dev['obs'].name) + '.dat'):
-                        os.remove(g_dev['obs'].obsid_path + 'ptr_night_shelf/' +
-                                  'pixelscale' + self.alias + str(g_dev['obs'].name) + '.dat')
-                    if os.path.exists(g_dev['obs'].obsid_path + 'ptr_night_shelf/' + 'pixelscale' + self.alias + str(g_dev['obs'].name) + '.dir'):
-                        os.remove(g_dev['obs'].obsid_path + 'ptr_night_shelf/' +
-                                  'pixelscale' + self.alias + str(g_dev['obs'].name) + '.dir')
-                    if os.path.exists(g_dev['obs'].obsid_path + 'ptr_night_shelf/' + 'pixelscale' + self.alias + str(g_dev['obs'].name) + '.bak'):
-                        os.remove(g_dev['obs'].obsid_path + 'ptr_night_shelf/' +
-                                  'pixelscale' + self.alias + str(g_dev['obs'].name) + '.bak')
+            plog("ALERT: PIXELSCALE SHELF CORRUPTED. WIPING AND STARTING AGAIN")
+            self.pixscale = None
+            plog(traceback.format_exc())
+            try:
+                if os.path.exists(g_dev['obs'].obsid_path + 'ptr_night_shelf/' + 'pixelscale' + self.alias + str(g_dev['obs'].name) + '.dat'):
+                    os.remove(g_dev['obs'].obsid_path + 'ptr_night_shelf/' +
+                                'pixelscale' + self.alias + str(g_dev['obs'].name) + '.dat')
+                if os.path.exists(g_dev['obs'].obsid_path + 'ptr_night_shelf/' + 'pixelscale' + self.alias + str(g_dev['obs'].name) + '.dir'):
+                    os.remove(g_dev['obs'].obsid_path + 'ptr_night_shelf/' +
+                                'pixelscale' + self.alias + str(g_dev['obs'].name) + '.dir')
+                if os.path.exists(g_dev['obs'].obsid_path + 'ptr_night_shelf/' + 'pixelscale' + self.alias + str(g_dev['obs'].name) + '.bak'):
+                    os.remove(g_dev['obs'].obsid_path + 'ptr_night_shelf/' +
+                                'pixelscale' + self.alias + str(g_dev['obs'].name) + '.bak')
 
-                except:
-                    plog(traceback.format_exc())
+            except:
+                plog(traceback.format_exc())
 
 
         """
@@ -3600,7 +3598,7 @@ class Camera:
 
                     # Stop if we're running from a block that has finished
                     if calendar_event_id is not None:
-                        if g_dev['seq'].schedule_manager.calendar_event_is_active(calendar_event_id):
+                        if not g_dev['seq'].schedule_manager.calendar_event_is_active(calendar_event_id):
                             plog('Calendar event is no longer active; cancelling current camera activity.')
                             Nsmartstack = 1
                             sskcounter = 2

--- a/devices/camera.py
+++ b/devices/camera.py
@@ -3439,9 +3439,9 @@ class Camera:
             observing_ends = self.obs.events['Observing Ends']
             naut_dusk = self.obs.events['Naut Dusk']
             naut_dawn = self.obs.events['Naut Dawn']
-            observng_begins = self.obs.events['Observing Begins']
-            
-            
+            observing_begins = self.obs.events['Observing Begins']
+
+
             if imtype.lower() in ["light", "expose"] and not self.obs.scope_in_manual_mode:
                 # Exposure time must end before the end of the nighttime observing window
                 if observing_ends < exposure_end_time:
@@ -3449,7 +3449,7 @@ class Camera:
                     self.running_an_exposure_set = False
                     return 'outsideofnighttime'
                 # Reject exposures that start before nautical dusk or end after nautical dawn
-                if now < observng_begins or exposure_end_time > observing_ends :
+                if now < observing_begins or exposure_end_time > observing_ends :
                     plog("Sorry, exposures are outside of night time.")
                     self.running_an_exposure_set = False
                     return 'outsideofnighttime'
@@ -4018,8 +4018,8 @@ class Camera:
                         self.shutter_open = False
                         continue
             self.currently_in_smartstack_loop = False
-            
-            
+
+
             self.write_out_realtimefiles_token_to_disk(real_time_token,real_time_files)
 
         # If the pier just flipped, trigger a recentering exposure.
@@ -4061,12 +4061,12 @@ class Camera:
             token_name (str): Token for real-time file tracking
             real_time_files (list): List of real-time file paths
         """
-        
-        # Append the seq number to the token_name 
+
+        # Append the seq number to the token_name
         # As it is possible to have two images taken very close in time
         token_name=token_name + str(self.next_seq)
-        
-        
+
+
         if self.site_config['save_raws_to_pipe_folder_for_nightly_processing']:
             if len(real_time_files) > 0:
                 pipetokenfolder = self.site_config['pipe_archive_folder_path'] + '/tokens'

--- a/devices/camera.py
+++ b/devices/camera.py
@@ -1371,6 +1371,9 @@ class Camera:
         self.end_of_last_exposure_time = time.time()
         self.camera_update_reboot = False
 
+        # Initialise variable to a blank array
+        self.current_focus_jpg=np.array([])
+
         # Figure out pixelscale from own observations
         # Or use the config value if there hasn't been enough
         # observations yet.

--- a/devices/camera.py
+++ b/devices/camera.py
@@ -3439,7 +3439,9 @@ class Camera:
             observing_ends = self.obs.events['Observing Ends']
             naut_dusk = self.obs.events['Naut Dusk']
             naut_dawn = self.obs.events['Naut Dawn']
-
+            observng_begins = self.obs.events['Observing Begins']
+            
+            
             if imtype.lower() in ["light", "expose"] and not self.obs.scope_in_manual_mode:
                 # Exposure time must end before the end of the nighttime observing window
                 if observing_ends < exposure_end_time:
@@ -3447,7 +3449,7 @@ class Camera:
                     self.running_an_exposure_set = False
                     return 'outsideofnighttime'
                 # Reject exposures that start before nautical dusk or end after nautical dawn
-                if now < naut_dusk or exposure_end_time > naut_dawn:
+                if now < observng_begins or exposure_end_time > observing_ends :
                     plog("Sorry, exposures are outside of night time.")
                     self.running_an_exposure_set = False
                     return 'outsideofnighttime'
@@ -4016,6 +4018,9 @@ class Camera:
                         self.shutter_open = False
                         continue
             self.currently_in_smartstack_loop = False
+            
+            
+            self.write_out_realtimefiles_token_to_disk(real_time_token,real_time_files)
 
         # If the pier just flipped, trigger a recentering exposure.
         # This is here because a single exposure may have a flip in it, hence
@@ -4037,7 +4042,7 @@ class Camera:
                 else:
                     pass
 
-        self.write_out_realtimefiles_token_to_disk(real_time_token, real_time_files)
+        #self.write_out_realtimefiles_token_to_disk(real_time_token, real_time_files)
 
         #  This is the loop point for the seq count loop
         self.currently_in_smartstack_loop = False
@@ -4056,6 +4061,12 @@ class Camera:
             token_name (str): Token for real-time file tracking
             real_time_files (list): List of real-time file paths
         """
+        
+        # Append the seq number to the token_name 
+        # As it is possible to have two images taken very close in time
+        token_name=token_name + str(self.next_seq)
+        
+        
         if self.site_config['save_raws_to_pipe_folder_for_nightly_processing']:
             if len(real_time_files) > 0:
                 pipetokenfolder = self.site_config['pipe_archive_folder_path'] + '/tokens'

--- a/devices/execute_project.py
+++ b/devices/execute_project.py
@@ -268,8 +268,12 @@ class SchedulerObservation:
         corrected_ra = proper_motion_parallax_adjusted_coords['ra'] + offset_ra
         corrected_dec = proper_motion_parallax_adjusted_coords['dec'] + offset_dec
 
-        plog(f'Slewing to ra {corrected_ra}, dec {corrected_dec}')
-        mount_device.go_command(ra=corrected_ra, dec=corrected_dec, objectname=target.get('name'))
+        if mount_device.last_ra_requested == corrected_ra and mount_device.last_dec_requested == corrected_dec:
+            plog(f'Mount is already pointing at ra {corrected_ra}, dec {corrected_dec}. No need to slew.')
+        else:
+            plog(f'Slewing to ra {corrected_ra}, dec {corrected_dec}')
+            mount_device.go_command(ra=corrected_ra, dec=corrected_dec, objectname=target.get('name'),
+                                    do_centering_routine=True, ignore_moon_dist=True)
 
     # Note: Defocus functionality not implemented, kept for API compatibility
     def _do_defocus(self, focuser_device, amount: float) -> None:

--- a/devices/execute_project.py
+++ b/devices/execute_project.py
@@ -237,6 +237,15 @@ class SchedulerObservation:
 
         self.submitter_id = observation['submitter']
 
+        # Check against this to determine whether a slew will require a full
+        # platesolve or not
+        self.last_requested_target = dict()
+
+        # Save the coordinates the mount believes it is pointing at (which may differ from the
+        # actual pointing), so that we can make use of the faster async_slew_direct function
+        self.last_solved_mount_ra = None
+        self.last_solved_mount_dec = None
+
         # This tracks how much time has been observed for each configuration
         # We use the configuration status id as the key because we need to
         # differentiate between the same config running multiple times from the
@@ -246,60 +255,57 @@ class SchedulerObservation:
             self.configuration_time_tracker[c['configuration_status']] = 0 # init with 0 seconds observed
 
 
-    def _go_to_target(self, mount_device, target: dict, offset_ra: float = 0, offset_dec: float = 0, current_block_ra: float = 0, current_block_dec: float=0, mosaic_center_ra: float=0, mosaic_center_dec: float=0) -> None:
+    def _go_to_target(self, mount_device, target: dict, offset_ra: float = 0, offset_dec: float = 0) -> None:
         """
         Slew to the target coordinates, applying any offsets
 
         Args:
             mount_device: The mount device to use for slewing
             target: Dictionary containing target coordinates and other info
-            offset_ra: Offset in right ascension (hours)
-            offset_dec: Offset in declination (degrees)
+            offset_ra: Offset in right ascension (arcseconds)
+            offset_dec: Offset in declination (arcseconds)
         """
         if target['type'] != "ICRS":
             plog(f'Unsupported target type: {target["type"]}')
             return
 
+        # convert from arcsec to hours
+        offset_ra = offset_ra / 54000
+        # convert from arcsec to degrees
+        offset_dec = offset_dec / 3600
+
         plog('In go_to_target function during LCO observation run')
         plog(target)
         # update the pointing to account for proper motion and parallax
         proper_motion_parallax_adjusted_coords = compute_target_coordinates(target)
+        ra = proper_motion_parallax_adjusted_coords['ra'] # units: hours
+        dec = proper_motion_parallax_adjusted_coords['dec'] # units: degrees
+        plog(f"central ra: {ra}")
+        plog(f"central dec: {dec}")
 
+        # Large mount movements should be centered using a platesolve routine.
+        # Do this whenever the target has changed from the previous pointing.
+        if self.last_requested_target != target:
+            mount_device.go_command(ra=ra, dec=dec, objectname=target.get('name'), do_centering_routine=True, ignore_moon_dist=True)
+            self.last_requested_target = target
+            # Save the mount coordinates (which are slightly different than the actual coordinates)
+            # for current/future offsets from the same central pointing
+            self.last_solved_mount_ra = mount_device.right_ascension_directly_from_mount
+            self.last_solved_mount_dec = mount_device.declination_directly_from_mount
+            plog(f"Pointing is now at ra,dec of {ra}, {dec} according to platesolve.")
+            plog(f"Mount has registered this as {self.last_solved_mount_ra}, {self.last_solved_mount_dec}")
 
-        # First decide if this positioning needs a platesolve
-        # We only need to platesolve to find the centrepoint of a series of offsets.
-        # If it isn't currently centered at the target central coordinates, do 
-        # a full platesolve slew.
-        if not (proper_motion_parallax_adjusted_coords['ra'] == current_block_ra and proper_motion_parallax_adjusted_coords['dec'] == current_block_dec):
-            mount_device.go_command(ra=corrected_ra, dec=corrected_dec, objectname=target.get('name'),
-                                    do_centering_routine=True, ignore_moon_dist=True)
-        
-        ## add ra/dec offsets
-        #corrected_ra = proper_motion_parallax_adjusted_coords['ra'] + offset_ra
-        #corrected_dec = proper_motion_parallax_adjusted_coords['dec'] + offset_dec
-        
-        # Once the platesolve have taken hold, we have the ra_scope, dec_scope of the ra_actual and the dec_actual
-        # The scope will ALWAYS be thinking it is pointing elsewhere. Every mount will always be off by some amount
-        # So here we use the - relatively rarely used - slew_async_directly - function to nudge the scope to the
-        # new offset. In the local area of the sky, this is acceptably accurate... actually pretty great.
-        # But you don't need to nudge if there is no offset.
-        if not (offset_ra == 0 and offset_dec == 0):
-            new_ra = mosaic_center_ra + offset_ra
-            new_dec= mosaic_center_dec + offset_dec
-            mount_device.slew_async_directly(ra=new_ra, dec=new_dec)
+        # If we're already close to our requested pointing, we can use a faster
+        # slewing method that isn't reliable for large movements, but works well
+        # for small adjustments
+        #
+        # The slew_async_directly method uses the mount coordinates rather than
+        # the actual coordinats, which is why we saved the mount ra/dec after
+        # the plate solve (above).
+        mount_ra_with_offset = self.last_solved_mount_ra + offset_ra
+        mount_dec_with_offset = self.last_solved_mount_dec + offset_dec
+        mount_device.slew_async_directly(ra=mount_ra_with_offset, dec=mount_dec_with_offset)
 
-
-
-
-
-
-
-        #if mount_device.last_ra_requested == corrected_ra and mount_device.last_dec_requested == corrected_dec:
-        #    plog(f'Mount is already pointing at ra {corrected_ra}, dec {corrected_dec}. No need to slew.')
-        #else:
-        #    plog(f'Slewing to ra {corrected_ra}, dec {corrected_dec}')
-        #    mount_device.go_command(ra=corrected_ra, dec=corrected_dec, objectname=target.get('name'),
-        #                            do_centering_routine=True, ignore_moon_dist=True)
 
     # Note: Defocus functionality not implemented, kept for API compatibility
     def _do_defocus(self, focuser_device, amount: float) -> None:
@@ -395,7 +401,7 @@ class SchedulerObservation:
             ''' Return True if configuration type is an exposure sequence and the duration has been exceeded'''
             return config_type == 'REPEAT_EXPOSE' and time.time() > end_time
 
-        self._go_to_target(devices['mount'], configuration['target'], self.devices['sequencer'].block_ra, self.devices['sequencer'].block_dec, self.devices['sequencer'].mosaic_center_ra, self.devices['sequencer'].mosaic_center_dec)
+        self._go_to_target(devices['mount'], configuration['target'])
 
         if config_type == "EXPOSE":
             for index, ic in enumerate(configuration['instrument_configs']):
@@ -464,7 +470,7 @@ class SchedulerObservation:
 
         offset_ra = ic['extra_params'].get('offset_ra', 0)
         offset_dec = ic['extra_params'].get('offset_dec', 0)
-        self._go_to_target(mount, config['target'], offset_ra, offset_dec, self.devices['sequencer'].block_dec, self.devices['sequencer'].mosaic_center_ra, self.devices['sequencer'].mosaic_center_dec)
+        self._go_to_target(mount, config['target'], offset_ra, offset_dec)
 
         exposure_time = ic['exposure_time']
         exposure_count = ic['exposure_count']

--- a/devices/mount.py
+++ b/devices/mount.py
@@ -630,7 +630,7 @@ class Mount:
 
         self.wait_for_mount_update()
         self.get_status()
-        
+
         #breakpoint()
 
 
@@ -1189,18 +1189,18 @@ class Mount:
                                             time.sleep(0.2)
                                     except:
                                         plog ("mount thread camera wait failed.")
-                                    
-                                    # Figure out the implied azimuth for that ra and dec at this location                      
-                                    observation_time=Time.now()                                    
+
+                                    # Figure out the implied azimuth for that ra and dec at this location
+                                    observation_time=Time.now()
                                     sky_coord=SkyCoord(ra=self.slewtoRA*15*u.deg, dec=self.slewtoDEC*u.deg)
                                     # Convert to AltAz frame
                                     altaz_frame = AltAz(obstime=observation_time, location=self.site_coordinates)
                                     altaz_coords = sky_coord.transform_to(altaz_frame)
-                                    
+
                                     # # Extract altitude and azimuth
                                     # obs_altitude = altaz_coords.alt.deg
                                     # obs_azimuth = altaz_coords.az.deg
-                                    
+
                                     self.target_az=altaz_coords.az.deg
                                     self.target_alt=altaz_coords.alt.deg
                                     self.mount_update_wincom.SlewToCoordinatesAsync(self.slewtoRA , self.slewtoDEC)
@@ -1353,10 +1353,10 @@ class Mount:
                 plog(traceback.format_exc())
 
     def wait_for_slew(self, wait_after_slew=True, wait_for_dome=True, wait_for_dome_after_direct_slew=True):
-        
-        
+
+
         wait_for_slew_timer=time.time()
-        
+
         try:
             actually_slewed=False
             if not self.rapid_park_indicator:
@@ -1369,36 +1369,36 @@ class Mount:
                         movement_reporting_timer = time.time()
                     self.get_mount_coordinates_after_next_update()
                     g_dev['obs'].update_status(mount_only=True, dont_wait=True)
-                    
-                    
+
+
                     # The planewave can (rarely, but non-zero)
                     # just get caught while slewing.
                     # This routine catches and remedies that.
-                    
+
                     if time.time() - wait_for_slew_timer > 120:
                         plog ("Waited too long to slew! What is going on?")
                         wait_for_slew_timer=time.time()
                         # Only happens with PWI4 for some reason
                         if self.driver=='ASCOM.PWI4.Telescope':
                             plog ("Too long on a PWI4. Rebooting PWI4 and getting it to get where it is meant to.")
-                            
+
                             os.system('taskkill /IM PWI4.exe /F')
                             time.sleep(10)
                             subprocess.Popen('"C:\Program Files (x86)\PlaneWave Instruments\PlaneWave Interface 4\PWI4.exe"', shell=True)
                             time.sleep(10)
                             urllib.request.urlopen("http://localhost:8220/mount/connect")
                             time.sleep(5)
-                            
+
                             self.mount_update_reboot=True
                             self.slewtoAsyncRequested=True
-                            
+
                             self.wait_for_mount_update=True
-                            
+
                             # Kick the telescope back to where it is meant to be pointing.
-                            
-                    
-                        
-                        
+
+
+
+
 
                 # Then wait for slew_time to settle
                 if actually_slewed and wait_after_slew:
@@ -1410,59 +1410,59 @@ class Mount:
             plog(traceback.format_exc())
             if self.theskyx:
                 g_dev['obs'].kill_and_reboot_theskyx(self.current_icrs_ra, self.current_icrs_dec)
-                
+
         # Then once it is slewed, if there is a dome, it has to wait for the dome.
-        # But if the dome isn't opened, then no reason to wait for the dome.        
+        # But if the dome isn't opened, then no reason to wait for the dome.
         if self.config['needs_to_wait_for_dome'] and wait_for_dome and not self.rapid_park_indicator and wait_for_dome_after_direct_slew:
             #plog ("making sure dome is positioned correct.")
             rd = SkyCoord(ra=self.right_ascension_directly_from_mount*u.hour, dec=self.declination_directly_from_mount*u.deg)
             aa = AltAz(location=self.site_coordinates, obstime=Time.now())
             rd = rd.transform_to(aa)
             obs_azimuth = float(rd.az/u.deg)
-            
-            
+
+
             wema_name=g_dev['obs'].config['wema_name']
             uri_status = f"https://status.photonranch.org/status/{wema_name}/enclosure"
 
 
-            
+
             try:
                 wema_enclosure_status=requests.get(uri_status, timeout=20)
                 dome_azimuth=wema_enclosure_status.json()['status']['enclosure']['enclosure1']['dome_azimuth']['val']
             except:
                 plog ("Some error in getting the wema_enclosure")
-            
-            
+
+
             # Only bother waiting if dome is open or opening
             if wema_enclosure_status.json()['status']['enclosure']['enclosure1']['shutter_status']['val'] in ['Open', 'open','Opening','opening']:
-            
+
                 #dome_azimuth= GET FROM wema
                 dome_timeout_timer=time.time()
                 #dome_open_or_opening=True
-                dome_is_slewing=wema_enclosure_status.json()['status']['enclosure']['enclosure1']['dome_slewing']['val'] 
+                dome_is_slewing=wema_enclosure_status.json()['status']['enclosure']['enclosure1']['dome_slewing']['val']
                 while (abs(obs_azimuth - dome_azimuth) > 15 or dome_is_slewing) and time.time() - dome_timeout_timer < 300 and not self.rapid_park_indicator: # and dome_open_or_opening:
-                    
+
                     #plog ("making sure dome is positioned correct.")
                     rd = SkyCoord(ra=self.right_ascension_directly_from_mount*u.hour, dec=self.declination_directly_from_mount*u.deg)
                     aa = AltAz(location=self.site_coordinates, obstime=Time.now())
                     rd = rd.transform_to(aa)
                     obs_azimuth = float(rd.az/u.deg)
-                    
+
                     plog ("d> " + str(obs_azimuth) + " " + str(dome_azimuth) + " " + " Dome Slewing: " + str(dome_is_slewing))
                     time.sleep(2)
                     try:
                         wema_enclosure_status=requests.get(uri_status, timeout=20)
                         dome_azimuth=wema_enclosure_status.json()['status']['enclosure']['enclosure1']['dome_azimuth']['val']
                         dome_open_or_opening=wema_enclosure_status.json()['status']['enclosure']['enclosure1']['shutter_status']['val'] in ['Open', 'open','Opening','opening']
-                        dome_is_slewing=wema_enclosure_status.json()['status']['enclosure']['enclosure1']['dome_slewing']['val'] 
+                        dome_is_slewing=wema_enclosure_status.json()['status']['enclosure']['enclosure1']['dome_slewing']['val']
                     except:
                         plog ("Some error in getting the wema_enclosure")
-                        
+
                 #plog ("Dome Arrived")
             else:
                 plog ("Why wait for the dome if it isn't even open?")
-                
-        
+
+
         return
 
     def return_side_of_pier(self):
@@ -1945,7 +1945,8 @@ class Mount:
     def go_command(self, skyflatspot=None, ra=None, dec=None, az=None, alt=None, ha=None, \
                    objectname=None, offset=False, calibrate=False, auto_center=False, \
                    silent=False, skip_open_test=False,tracking_rate_ra = 0, \
-                   tracking_rate_dec =  0, do_centering_routine=False, dont_wait_after_slew=False):
+                   tracking_rate_dec =  0, do_centering_routine=False, dont_wait_after_slew=False, \
+                   ignore_moon_dist=False):
 
         ''' Slew to the given ra/dec, alt/az or ha/dec or skyflatspot coordinates. '''
 
@@ -2019,7 +2020,7 @@ class Mount:
 
         # Second thing, check that we aren't pointing at the moon
         # UNLESS we have actually chosen to look at the moon.
-        if g_dev['obs'].moon_checks_on:
+        if g_dev['obs'].moon_checks_on and not ignore_moon_dist:
             if self.object in ['Moon', 'moon', 'Lune', 'lune', 'Luna', 'luna',]:
                 plog("Moon Request detected")
             else:

--- a/devices/schedule_manager.py
+++ b/devices/schedule_manager.py
@@ -1,135 +1,3 @@
-sample_ptr_calendar_response = [
-    {
-        "origin": "PTR",
-        "creator": "Tim Beccue",
-        "resourceId": "tbo2",
-        "site": "tbo2",
-        "creator_id": "google-oauth2|100354044221813550027",
-        "reservation_note": "",
-        "event_id": "a179dcad-d7b4-40c8-9a4e-bf2f0df0d9ff",
-        "reservation_type": "project",
-        "project_id": "Simple observation from LCO - tbo2#2025-02-04T05:04:55Z",
-        "end": "2025-03-08T01:35:00Z",
-        "project_priority": "standard",
-        "last_modified": "2025-03-08T00:30:54Z",
-        "start": "2025-03-07T23:35:00Z",
-        "title": "Tim Beccue",
-    }
-]
-
-sample_site_proxy_schedule_response = {
-    "count": 74,
-    "next": None,
-    "previous": None,
-    "results": [
-        {
-            "created": "2025-02-15T02:33:31.083076Z",
-            "enclosure": "enc1",
-            "end": "2025-02-15T03:11:43Z",
-            "id": 583120106,
-            "ipp_value": 1.05,
-            "modified": "2025-02-15T02:33:31.083071Z",
-            "name": "Full Complete Observation mrc1",
-            "observation_type": "NORMAL",
-            "priority": 10,
-            "proposal": "PTR_integration_test_proposal",
-            "request": {
-                "acceptability_threshold": 90.0,
-                "configuration_repeats": 2,
-                "configurations": [
-                    {
-                        "acquisition_config": {
-                            "extra_params": {},
-                            "mode": "OFF",
-                        },
-                        "configuration_status": 750654859,
-                        "constraints": {
-                            "extra_params": {},
-                            "max_airmass": 1.6,
-                            "max_lunar_phase": 1.0,
-                            "min_lunar_distance": 30.0,
-                        },
-                        "extra_params": {
-                            "dither_pattern": "custom",
-                            "smartstack": True,
-                            "substack": True,
-                        },
-                        "guide_camera_name": "",
-                        "guiding_config": {
-                            "exposure_time": None,
-                            "extra_params": {},
-                            "mode": "OFF",
-                            "optical_elements": {},
-                            "optional": True,
-                        },
-                        "id": 10840803,
-                        "instrument_configs": [
-                            {
-                                "exposure_count": 10,
-                                "exposure_time": 15.0,
-                                "extra_params": {
-                                    "offset_dec": 1,
-                                    "offset_ra": 2,
-                                    "rotator_angle": 0,
-                                },
-                                "mode": "full",
-                                "optical_elements": {"filter": "ptr-w"},
-                                "rois": [],
-                                "rotator_mode": "RPA",
-                            },
-                            {
-                                "exposure_count": 40,
-                                "exposure_time": 10.0,
-                                "extra_params": {
-                                    "offset_dec": 0,
-                                    "offset_ra": 0,
-                                    "rotator_angle": 0,
-                                },
-                                "mode": "full",
-                                "optical_elements": {"filter": "ptr-w"},
-                                "rois": [],
-                                "rotator_mode": "RPA",
-                            },
-                        ],
-                        "instrument_name": "qhy461",
-                        "instrument_type": "PTR-MRC1-0M31-QHY461",
-                        "priority": 1,
-                        "repeat_duration": None,
-                        "state": "PENDING",
-                        "summary": {},
-                        "target": {
-                            "dec": -7.6528696608383,
-                            "epoch": 2000.0,
-                            "extra_params": {},
-                            "hour_angle":None,
-                            "name": "40 Eridani",
-                            "parallax": 199.608,
-                            "proper_motion_dec": -3421.809,
-                            "proper_motion_ra": -2240.085,
-                            "ra": 63.8179984124771,
-                            "type": "ICRS",
-                        },
-                        "type": "EXPOSE",
-                    }
-                ],
-                "duration": 2094,
-                "extra_params": {},
-                "id": 3445217,
-                "modified": "2025-02-18T14:35:00.293445Z",
-                "observation_note": "",
-                "optimization_type": "TIME",
-                "state": "WINDOW_EXPIRED",
-            },
-            "request_group_id": 1885231,
-            "site": "mrc",
-            "start": "2025-02-15T02:36:49Z",
-            "state": "PENDING",
-            "submitter": "tbeccue",
-            "telescope": "0m31",
-        },
-    ],
-}
-
 
 from datetime import datetime
 from dateutil import parser
@@ -591,22 +459,135 @@ class NightlyScheduleManager:
         self._stop_threads.clear()
 
 
+# These are examples for reference. They are not used in the code.
+sample_ptr_calendar_response = [
+    {
+        "origin": "PTR",
+        "creator": "Tim Beccue",
+        "resourceId": "tbo2",
+        "site": "tbo2",
+        "creator_id": "google-oauth2|100354044221813550027",
+        "reservation_note": "",
+        "event_id": "a179dcad-d7b4-40c8-9a4e-bf2f0df0d9ff",
+        "reservation_type": "project",
+        "project_id": "Simple observation from LCO - tbo2#2025-02-04T05:04:55Z",
+        "end": "2025-03-08T01:35:00Z",
+        "project_priority": "standard",
+        "last_modified": "2025-03-08T00:30:54Z",
+        "start": "2025-03-07T23:35:00Z",
+        "title": "Tim Beccue",
+    }
+]
 
-def test_schedule_manager():
-    ptr_update_interval = 5
-    lco_update_intervale = 3
-    os.environ['SITE_PROXY_BASE_URL'] = "https://mrc-proxy.lco.global"
-    os.environ['SITE_PROXY_TOKEN'] = "bdb38dbd-c22e-4766-8553-4a0713ea824e"
-    test_start = parser.parse("2025-03-03T00:36:49Z").timestamp()
-    test_end   = parser.parse("2025-03-05T00:36:49Z").timestamp()
-    test_end = time.time() + 60*60*24
-    sm = NightlyScheduleManager("mrc1", test_start, test_end, "0m31", lco_update_interval=lco_update_intervale, ptr_update_interval=ptr_update_interval)
-    # sm = NightlyScheduleManager("tbo2", test_start, test_end, lco_update_interval=lco_update_intervale, ptr_update_interval=ptr_update_interval)
-    sm.start_update_threads()
-    print('start sleep')
-    time.sleep(10)
-    print('end sleep')
-    # print(sm.schedule)
-    print(sm.simple_schedule)
-    print(sm.events_happening_now())
-    print(sm.get_observation_to_run_now())
+sample_site_proxy_schedule_response = {
+    "count": 74,
+    "next": None,
+    "previous": None,
+    "results": [
+        {
+            "created": "2025-02-15T02:33:31.083076Z",
+            "enclosure": "enc1",
+            "end": "2025-02-15T03:11:43Z",
+            "id": 583120106,
+            "ipp_value": 1.05,
+            "modified": "2025-02-15T02:33:31.083071Z",
+            "name": "Full Complete Observation mrc1",
+            "observation_type": "NORMAL",
+            "priority": 10,
+            "proposal": "PTR_integration_test_proposal",
+            "request": {
+                "acceptability_threshold": 90.0,
+                "configuration_repeats": 2,
+                "configurations": [
+                    {
+                        "acquisition_config": {
+                            "extra_params": {},
+                            "mode": "OFF",
+                        },
+                        "configuration_status": 750654859,
+                        "constraints": {
+                            "extra_params": {},
+                            "max_airmass": 1.6,
+                            "max_lunar_phase": 1.0,
+                            "min_lunar_distance": 30.0,
+                        },
+                        "extra_params": {
+                            "dither_pattern": "custom",
+                            "smartstack": True,
+                            "substack": True,
+                        },
+                        "guide_camera_name": "",
+                        "guiding_config": {
+                            "exposure_time": None,
+                            "extra_params": {},
+                            "mode": "OFF",
+                            "optical_elements": {},
+                            "optional": True,
+                        },
+                        "id": 10840803,
+                        "instrument_configs": [
+                            {
+                                "exposure_count": 10,
+                                "exposure_time": 15.0,
+                                "extra_params": {
+                                    "offset_dec": 1,
+                                    "offset_ra": 2,
+                                    "rotator_angle": 0,
+                                },
+                                "mode": "full",
+                                "optical_elements": {"filter": "ptr-w"},
+                                "rois": [],
+                                "rotator_mode": "RPA",
+                            },
+                            {
+                                "exposure_count": 40,
+                                "exposure_time": 10.0,
+                                "extra_params": {
+                                    "offset_dec": 0,
+                                    "offset_ra": 0,
+                                    "rotator_angle": 0,
+                                },
+                                "mode": "full",
+                                "optical_elements": {"filter": "ptr-w"},
+                                "rois": [],
+                                "rotator_mode": "RPA",
+                            },
+                        ],
+                        "instrument_name": "qhy461",
+                        "instrument_type": "PTR-MRC1-0M31-QHY461",
+                        "priority": 1,
+                        "repeat_duration": None,
+                        "state": "PENDING",
+                        "summary": {},
+                        "target": {
+                            "dec": -7.6528696608383,
+                            "epoch": 2000.0,
+                            "extra_params": {},
+                            "hour_angle":None,
+                            "name": "40 Eridani",
+                            "parallax": 199.608,
+                            "proper_motion_dec": -3421.809,
+                            "proper_motion_ra": -2240.085,
+                            "ra": 63.8179984124771,
+                            "type": "ICRS",
+                        },
+                        "type": "EXPOSE",
+                    }
+                ],
+                "duration": 2094,
+                "extra_params": {},
+                "id": 3445217,
+                "modified": "2025-02-18T14:35:00.293445Z",
+                "observation_note": "",
+                "optimization_type": "TIME",
+                "state": "WINDOW_EXPIRED",
+            },
+            "request_group_id": 1885231,
+            "site": "mrc",
+            "start": "2025-02-15T02:36:49Z",
+            "state": "PENDING",
+            "submitter": "tbeccue",
+            "telescope": "0m31",
+        },
+    ],
+}

--- a/devices/schedule_manager.py
+++ b/devices/schedule_manager.py
@@ -1,0 +1,612 @@
+sample_ptr_calendar_response = [
+    {
+        "origin": "PTR",
+        "creator": "Tim Beccue",
+        "resourceId": "tbo2",
+        "site": "tbo2",
+        "creator_id": "google-oauth2|100354044221813550027",
+        "reservation_note": "",
+        "event_id": "a179dcad-d7b4-40c8-9a4e-bf2f0df0d9ff",
+        "reservation_type": "project",
+        "project_id": "Simple observation from LCO - tbo2#2025-02-04T05:04:55Z",
+        "end": "2025-03-08T01:35:00Z",
+        "project_priority": "standard",
+        "last_modified": "2025-03-08T00:30:54Z",
+        "start": "2025-03-07T23:35:00Z",
+        "title": "Tim Beccue",
+    }
+]
+
+sample_site_proxy_schedule_response = {
+    "count": 74,
+    "next": None,
+    "previous": None,
+    "results": [
+        {
+            "created": "2025-02-15T02:33:31.083076Z",
+            "enclosure": "enc1",
+            "end": "2025-02-15T03:11:43Z",
+            "id": 583120106,
+            "ipp_value": 1.05,
+            "modified": "2025-02-15T02:33:31.083071Z",
+            "name": "Full Complete Observation mrc1",
+            "observation_type": "NORMAL",
+            "priority": 10,
+            "proposal": "PTR_integration_test_proposal",
+            "request": {
+                "acceptability_threshold": 90.0,
+                "configuration_repeats": 2,
+                "configurations": [
+                    {
+                        "acquisition_config": {
+                            "extra_params": {},
+                            "mode": "OFF",
+                        },
+                        "configuration_status": 750654859,
+                        "constraints": {
+                            "extra_params": {},
+                            "max_airmass": 1.6,
+                            "max_lunar_phase": 1.0,
+                            "min_lunar_distance": 30.0,
+                        },
+                        "extra_params": {
+                            "dither_pattern": "custom",
+                            "smartstack": True,
+                            "substack": True,
+                        },
+                        "guide_camera_name": "",
+                        "guiding_config": {
+                            "exposure_time": None,
+                            "extra_params": {},
+                            "mode": "OFF",
+                            "optical_elements": {},
+                            "optional": True,
+                        },
+                        "id": 10840803,
+                        "instrument_configs": [
+                            {
+                                "exposure_count": 10,
+                                "exposure_time": 15.0,
+                                "extra_params": {
+                                    "offset_dec": 1,
+                                    "offset_ra": 2,
+                                    "rotator_angle": 0,
+                                },
+                                "mode": "full",
+                                "optical_elements": {"filter": "ptr-w"},
+                                "rois": [],
+                                "rotator_mode": "RPA",
+                            },
+                            {
+                                "exposure_count": 40,
+                                "exposure_time": 10.0,
+                                "extra_params": {
+                                    "offset_dec": 0,
+                                    "offset_ra": 0,
+                                    "rotator_angle": 0,
+                                },
+                                "mode": "full",
+                                "optical_elements": {"filter": "ptr-w"},
+                                "rois": [],
+                                "rotator_mode": "RPA",
+                            },
+                        ],
+                        "instrument_name": "qhy461",
+                        "instrument_type": "PTR-MRC1-0M31-QHY461",
+                        "priority": 1,
+                        "repeat_duration": None,
+                        "state": "PENDING",
+                        "summary": {},
+                        "target": {
+                            "dec": -7.6528696608383,
+                            "epoch": 2000.0,
+                            "extra_params": {},
+                            "hour_angle":None,
+                            "name": "40 Eridani",
+                            "parallax": 199.608,
+                            "proper_motion_dec": -3421.809,
+                            "proper_motion_ra": -2240.085,
+                            "ra": 63.8179984124771,
+                            "type": "ICRS",
+                        },
+                        "type": "EXPOSE",
+                    }
+                ],
+                "duration": 2094,
+                "extra_params": {},
+                "id": 3445217,
+                "modified": "2025-02-18T14:35:00.293445Z",
+                "observation_note": "",
+                "optimization_type": "TIME",
+                "state": "WINDOW_EXPIRED",
+            },
+            "request_group_id": 1885231,
+            "site": "mrc",
+            "start": "2025-02-15T02:36:49Z",
+            "state": "PENDING",
+            "submitter": "tbeccue",
+            "telescope": "0m31",
+        },
+    ],
+}
+
+
+from datetime import datetime
+from dateutil import parser
+import time
+import json
+import requests
+import os
+import threading
+from devices.sequencer_helpers import is_valid_utc_iso
+from ptr_utility import plog
+
+
+class NightlyScheduleManager:
+    def __init__(self,
+                 site: str,
+                 schedule_start: int,
+                 schedule_end: int,
+                 ptr_update_interval: int=60,  # Default to 60 seconds
+                 lco_update_interval: int=30,   # Default to 30 seconds
+                 include_lco_scheduler: bool=True,
+                 configdb_telescope: str=None,
+                 configdb_enclosure: str=None,
+                ):
+        """ A class that manages the schedule for the night. This class is responsible for getting the schedule from the
+        site proxy and the PTR calendar and keeping track of the events that are happening.
+
+        Args:
+        - site (str): the ptr site (e.g. mrc1). Used for fetching PTR calendar events.
+        - schedule_start (int): unix timestamp; get events that start after this time
+        - schedule_end   (int): unix timestamp; get events that end before this time
+        - ptr_update_interval (int): How often to update PTR schedule in seconds
+        - lco_update_interval (int): How often to update LCO schedule in seconds
+        - include_lco_scheduler (bool): if this is false, we won't show errors for missing LCO scheduler info
+        - configdb_telescope (str): the telecope id used in configdb, used to
+            filter the site proxy schedules to only include this site
+        - configdb_enclosure (str): name of the enclosure in configdb, used like above
+        """
+
+        self.site_proxy_offline = False
+        if include_lco_scheduler:
+            if 'SITE_PROXY_BASE_URL' not in os.environ:
+                plog('ERROR: the environment variable SITE_PROXY_BASE_URL is missing and scheduler observations won\'t work.')
+                plog('Please add this to the .env file and restart the observatory.')
+                self.site_proxy_offline = True
+            if 'SITE_PROXY_TOKEN' not in os.environ:
+                plog('ERROR: the environment variable SITE_PROXY_TOKEN is missing, which means we can\'t communicate with the site proxy')
+                plog('Please add this to the .env file and restart the observatory.')
+                self.site_proxy_offline = True
+            if configdb_telescope == None:
+                plog('ERROR: the configdb_telescope is not set. This is required to fetch the schedule from the site proxy.')
+                plog('Observations from the scheduler will not be fetched.')
+                self.site_proxy_offline = True
+            if configdb_enclosure == None:
+                plog('WARNING: the configdb_enclosure is not set. This is useful for better filtering of site proxy scheudles.')
+                plog('It should be an easy value to add to the site config')
+        self.site_proxy_base_url = os.getenv('SITE_PROXY_BASE_URL')
+        self.site_proxy = requests.Session()
+        self.site_proxy.headers.update({'Authorization': os.getenv('SITE_PROXY_TOKEN')})
+        self.configdb_telescope = configdb_telescope
+        self.configdb_enclosure = configdb_enclosure
+
+        self.site = site
+
+        if schedule_start > schedule_end:
+            plog("ERROR: schedule_start is after schedule_end. This is probably not what you want.")
+        if schedule_end < time.time():
+            plog("WARNING: schedule_end is in the past. This is probably not what you want.")
+        self.schedule_start = schedule_start
+        self.schedule_end   = schedule_end
+
+        self._ptr_events = []
+        self._lco_events = []
+        self._time_of_last_lco_schedule = None
+
+        self._completed_ids = []
+
+        # Thread control variables
+        self.ptr_update_interval = ptr_update_interval
+        self.lco_update_interval = lco_update_interval
+        self._stop_threads = threading.Event()
+
+        # Thread objects
+        self._ptr_thread = None
+        self._lco_thread = None
+
+        # Thread status indicators
+        self.ptr_thread_running = False
+        self.lco_thread_running = False
+
+        # Lock for thread-safe operations
+        self._lock = threading.RLock()
+
+        self.start_update_threads()
+
+
+    def _timestamp(self, date: str):
+        """ Automatically convert the date formats to unix timestamps
+
+        Designed to supported date formats found in the responses from the PTR calendar and the site proxy:
+        - "2025-02-15T02:36:49Z"
+        - "2025-02-15T02:36:49.123456Z"
+        """
+        try:
+            return parser.parse(date).timestamp()
+        except:
+            return None
+
+
+    def _get_lco_last_scheduled(self):
+        """
+        Get the time the latest schedule was created by the LCO scheduler
+        This is useful to know if we need to update the schedule or not.
+        """
+        if self.site_proxy_offline:
+            return
+        url = self.site_proxy_base_url + '/observation-portal/api/last_scheduled/'
+        response = self.site_proxy.get(url)
+        plog(response.json())
+        return response.json().get('last_scheduled')
+
+
+    def update_lco_schedule(self, start_time=None, end_time=None):
+        """
+        Get the latest schedule for this site from the site proxy.
+        This function only gets the schedule if it's changed since the last request.
+
+        Args:
+        - start_time (str): get events ending after this time. string formatted as YYYY-mm-ddTHH:MM:SSZ
+        - end_time (str): get events ending before this time. string formatted as YYYY-mm-ddTHH:MM:SSZ
+        """
+        if self.site_proxy_offline:
+            return
+
+        # First check if there's anything new since last time we checked
+        last_lco_schedule_time = self._get_lco_last_scheduled()
+        if self._time_of_last_lco_schedule and self._time_of_last_lco_schedule == last_lco_schedule_time:
+            return
+
+        # Update the last scheduled time and proceed with fetching the latest
+        self._time_of_last_lco_schedule = last_lco_schedule_time
+
+        if start_time is None or not is_valid_utc_iso(start_time):
+            start_time = datetime.fromtimestamp(self.schedule_start).isoformat().split(".")[0]
+        if end_time is None or not is_valid_utc_iso(end_time):
+            end_time = datetime.fromtimestamp(self.schedule_end).isoformat().split(".")[0]
+
+        url = self.site_proxy_base_url + '/observation-portal/api/schedule/'
+        params = {
+            'start': start_time,
+            'end': end_time,
+            'telescope': self.configdb_telescope,
+            'enclosure': self.configdb_enclosure
+        }
+        try:
+            events = self.site_proxy.get(url, params=params).json().get('results', [])
+        except:
+            plog(f"Failed to update the LCO schedule. Request url was {url} and url params were {params}.")
+            events = []
+
+        with self._lock:
+            self._lco_events = [
+                {
+                    "start": self._timestamp(event["start"]),
+                    "end": self._timestamp(event["end"]),
+                    "id": event["id"],
+                    "origin": "lco",
+                    "event": event
+                }
+                for event in events
+            ]
+
+    def update_ptr_schedule(self, start_time=None, end_time=None):
+        """
+        A function called that updates the calendar blocks - both to get new calendar blocks and to
+        check that any running calendar blocks are still there with the same time window.
+
+        Args:
+        - start_time (str): get events ending after this time. string formatted as YYYY-mm-ddTHH:MM:SSZ
+        - end_time (str): get events ending before this time. string formatted as YYYY-mm-ddTHH:MM:SSZ
+        """
+
+        calendar_update_url = "https://calendar.photonranch.org/calendar/siteevents"
+
+        if start_time is None or not is_valid_utc_iso(start_time):
+            start_time = datetime.fromtimestamp(self.schedule_start).isoformat().split(".")[0] + "Z"
+        if end_time is None or not is_valid_utc_iso(end_time):
+            end_time = datetime.fromtimestamp(self.schedule_end).isoformat().split(".")[0] + "Z"
+
+        # Make sure the times are formatted correctly
+        if not is_valid_utc_iso(start_time):
+            raise ValueError(f"start_time must be formatted YYYY-m-ddTHH:MM:SSZ. Actual input was {start_time}")
+        if not is_valid_utc_iso(end_time):
+            raise ValueError(f"end_time must be formatted YYYY-m-ddTHH:MM:SSZ. Actual input was {end_time}")
+
+        body = json.dumps({
+            "site": self.site,
+            "start": start_time,
+            "end": end_time,
+            "full_project_details": False,
+        })
+
+        try:
+            events = requests.post(calendar_update_url, body, timeout=20).json()
+        except:
+            plog(f"ERROR: Failed to update the calendar. This is not normal. Request url was {calendar_update_url} and body was {body}.")
+            events = []
+
+        with self._lock:
+            self._ptr_events = [
+                {
+                    "start": self._timestamp(event["start"]),
+                    "end": self._timestamp(event["end"]),
+                    "id": event["event_id"],
+                    "origin": "ptr",
+                    "event": event
+                }
+                for event in events
+            ]
+
+    def get_ptr_project_details(self, event):
+        """ Get the project details associated a PTR calendar event """
+        event = event['event']
+        # for reasons, these are possible project_id values when no project is
+        # associated with the event
+        null_project_ids = [None, 'none', 'none#']
+        if 'project_id' not in event or event['project_id'] in null_project_ids:
+            return None
+
+        url_proj = "https://projects.photonranch.org/projects/get-project"
+        request_body = json.dumps({
+            "project_name": event['project_id'].split('#')[0],
+            "created_at": event['project_id'].split('#')[1],
+        })
+        response = requests.post(url_proj, request_body, timeout=10)
+
+        if response.status_code == 200:
+            project = response.json()
+            return project
+
+        else:
+            plog('Failed to retrieve project details for event: ', event)
+            return None
+
+    def update_now(self, override_warning=False):
+        """ Update the schedule now """
+        if not override_warning:
+            plog(f'Updating full schedule now. Note that this already happens every {self.ptr_update_interval}s and {self.lco_update_interval}s so it may not be necessary to call this manually.')
+        # Create threads for each update operation
+        lco_thread = threading.Thread(
+            target=self.update_lco_schedule,
+            name="LCO_Update_Now_Thread",
+            daemon=True
+        )
+
+        ptr_thread = threading.Thread(
+            target=self.update_ptr_schedule,
+            name="PTR_Update_Now_Thread",
+            daemon=True
+        )
+
+        # Start both threads
+        lco_thread.start()
+        ptr_thread.start()
+
+        # Wait for both threads to complete
+        lco_thread.join()
+        ptr_thread.join()
+
+
+    def add_completed_id(self, id):
+        """ Mark this event as complete, so we can avoid trying to run it again """
+        with self._lock:
+            self._completed_ids.append(id)
+
+    def check_is_completed(self, id):
+        """ Check if an event has been marked as completed"""
+        with self._lock:
+            return id in self._completed_ids
+
+    def clear_completed_ids(self):
+        """ Clear the list of completed events """
+        with self._lock:
+            self._completed_ids = []
+
+    def reset(self, start=None, end=None):
+        """Reset the schedule manager with new observing times."""
+
+        # Stop the threads if they're running
+        self.stop_update_threads()
+
+        with self._lock:
+            if start != None:
+                self.schedule_start = start
+            if end != None:
+                self.schedule_end = end
+            self._ptr_events = []
+            self._lco_events = []
+            self._time_of_last_lco_schedule = None
+            self._completed_ids = []
+
+        # Restart the threads if they were running before
+        if self.ptr_thread_running or self.lco_thread_running:
+            self.start_update_threads()
+
+    @property
+    def schedule(self):
+        """ Return the list of all events sorted by start time"""
+        with self._lock:
+            all_events = self._ptr_events + self._lco_events
+            return sorted(all_events, key=lambda x: x["start"])
+
+    @property
+    def simple_schedule(self):
+        """ Return a simplified version of the schedule, with only the start and end times"""
+        with self._lock:
+            return [
+                {
+                    "start": event["start"],
+                    "end": event["end"],
+                    "origin": event["origin"],
+                    "id": event["id"],
+                }
+                for event in self.schedule
+            ]
+
+    @property
+    def schedule_is_empty(self):
+        with self._lock:
+            return len(self._ptr_events + self._lco_events) == 0
+
+    def events_happening_now(self):
+        now_events = []
+        now = time.time()
+        with self._lock:
+            for event in self.schedule:
+                if event["start"] <= now <= event["end"]:
+                    now_events.append(event)
+        return now_events
+
+    def calendar_event_is_active(event_id):
+        """ Check if a calendar event is active """
+        return event_id in [event["id"] for event in self.events_happening_now()]
+
+    def get_observation_to_run_now(self):
+        """
+        Get an observation that is scheduled to run now.
+        If there are any observations from the LCO scheduler, return the first one.
+        Otherwise, return the first PTR event with a project attached.
+
+        Response format follows the format of the events in the schedule list,
+        with the addition of a 'project' key that contains the project details
+        for PTR projects:
+        {
+            'id': str,
+            'start': timestamp,     # unix
+            'end': timestamp,       # unix
+            'origin': str,          # 'ptr' or 'lco'
+            'event': {
+                'project': dict,    # only present if origin is 'ptr'
+                ...                 # this would be the rest of the calendar event for ptr,
+                                      or an observation 'result' from the site_proxy for lco.
+            }
+        }
+
+        """
+        if self.schedule_is_empty:
+            return None
+
+        with self._lock:
+            current_events = self.events_happening_now()
+            current_events = [x for x in current_events if not self.check_is_completed(x["id"])]
+
+            for event in current_events:
+                # First check for scheduler events, and return the first one if available
+                if event["origin"] == "lco":
+                    return event
+
+                # If no scheduler events are available, return the first PTR event with
+                # a project associated with it
+                else:
+                    project = self.get_ptr_project_details(event)
+                    if project:
+                        return {
+                            **event,
+                            'event': {
+                                **event['event'],
+                                'project': project
+                            }
+                        }
+
+        # If no events with projects/observations are available, return None
+        return None
+
+    def _ptr_update_loop(self):
+        """Thread function that updates the PTR schedule at regular intervals."""
+        self.ptr_thread_running = True
+
+        while not self._stop_threads.is_set():
+            try:
+                self.update_ptr_schedule()
+            except Exception as e:
+                plog(f"Error in PTR schedule update thread: {str(e)}")
+
+            # Sleep until next update interval or until stopped
+            self._stop_threads.wait(self.ptr_update_interval)
+
+        self.ptr_thread_running = False
+
+    def _lco_update_loop(self):
+        """Thread function that updates the LCO schedule at regular intervals."""
+        self.lco_thread_running = True
+
+        while not self._stop_threads.is_set():
+            try:
+                self.update_lco_schedule()
+            except Exception as e:
+                plog(f"Error in LCO schedule update thread: {str(e)}")
+
+            # Sleep until next update interval or until stopped
+            self._stop_threads.wait(self.lco_update_interval)
+
+        self.lco_thread_running = False
+
+    def start_update_threads(self):
+        """Start the schedule update threads."""
+        with self._lock:
+            # Only start threads if they're not already running
+            if not self.ptr_thread_running:
+                self._ptr_thread = threading.Thread(
+                    target=self._ptr_update_loop,
+                    name="PTRScheduleUpdateThread",
+                    daemon=True  # Make thread a daemon so it exits when main program exits
+                )
+                self._ptr_thread.start()
+
+            if not self.lco_thread_running:
+                self._lco_thread = threading.Thread(
+                    target=self._lco_update_loop,
+                    name="LCOScheduleUpdateThread",
+                    daemon=True  # Make thread a daemon so it exits when main program exits
+                )
+                self._lco_thread.start()
+
+    def stop_update_threads(self):
+        """Stop the schedule update threads."""
+        if not (self.ptr_thread_running or self.lco_thread_running):
+            return
+
+        self._stop_threads.set()
+
+        # Wait for threads to complete if they're running
+        if self._ptr_thread and self._ptr_thread.is_alive():
+            self._ptr_thread.join(timeout=2.0)  # Wait up to 2 seconds for thread to finish
+
+        if self._lco_thread and self._lco_thread.is_alive():
+            self._lco_thread.join(timeout=2.0)  # Wait up to 2 seconds for thread to finish
+
+        # Reset the stop event
+        self._stop_threads.clear()
+
+
+
+def test_schedule_manager():
+    ptr_update_interval = 5
+    lco_update_intervale = 3
+    os.environ['SITE_PROXY_BASE_URL'] = "https://mrc-proxy.lco.global"
+    os.environ['SITE_PROXY_TOKEN'] = "bdb38dbd-c22e-4766-8553-4a0713ea824e"
+    test_start = parser.parse("2025-03-03T00:36:49Z").timestamp()
+    test_end   = parser.parse("2025-03-05T00:36:49Z").timestamp()
+    test_end = time.time() + 60*60*24
+    sm = NightlyScheduleManager("mrc1", test_start, test_end, "0m31", lco_update_interval=lco_update_intervale, ptr_update_interval=ptr_update_interval)
+    # sm = NightlyScheduleManager("tbo2", test_start, test_end, lco_update_interval=lco_update_intervale, ptr_update_interval=ptr_update_interval)
+    sm.start_update_threads()
+    print('start sleep')
+    time.sleep(10)
+    print('end sleep')
+    # print(sm.schedule)
+    print(sm.simple_schedule)
+    print(sm.events_happening_now())
+    print(sm.get_observation_to_run_now())

--- a/devices/schedule_manager.py
+++ b/devices/schedule_manager.py
@@ -469,7 +469,7 @@ class NightlyScheduleManager:
                     now_events.append(event)
         return now_events
 
-    def calendar_event_is_active(event_id):
+    def calendar_event_is_active(self, event_id):
         """ Check if a calendar event is active """
         return event_id in [event["id"] for event in self.events_happening_now()]
 

--- a/devices/schedule_manager.py
+++ b/devices/schedule_manager.py
@@ -115,7 +115,6 @@ class NightlyScheduleManager:
             return
         url = self.site_proxy_base_url + '/observation-portal/api/last_scheduled/'
         response = self.site_proxy.get(url)
-        plog(response.json())
         return response.json().get('last_scheduled')
 
 

--- a/devices/sequencer.py
+++ b/devices/sequencer.py
@@ -190,6 +190,8 @@ class Sequencer:
         self.block_ra=False
         self.block_dec=False
 
+        self.lco_block=False
+
         # Time of next slew is a variable that helps keep the scope positioned on the solar flat spot during flats
         self.time_of_next_slew = time.time()
 
@@ -806,6 +808,7 @@ class Sequencer:
 
                         self.block_guard = True
                         self.total_sequencer_control= True
+                        self.lco_block=True
 
                         #breakpoint()
                         # Run the observation
@@ -813,6 +816,7 @@ class Sequencer:
 
                         # Allow manual commands now that the project has completed
                         self.block_guard = False
+                        self.lco_block=False
                         self.total_sequencer_control= False
 
                     # Run a PTR project
@@ -1176,14 +1180,14 @@ class Sequencer:
         # Protect from manual commands interferring
         self.block_guard = True
         self.total_sequencer_control= True
-
+        self.lco_block=True
         #breakpoint()
 
         # Run the project
         observation = json.loads(block_specification['project']['full_lco_observation'])
         # execute_project_from_lco1(observation, self.obs)
         SchedulerObservation(observation, self.obs).run()
-
+        self.lco_block=False
         # Allow manual commands now that the project has completed
         self.block_guard = False
         self.total_sequencer_control= False

--- a/devices/sequencer.py
+++ b/devices/sequencer.py
@@ -823,6 +823,7 @@ class Sequencer:
                             self.schedule_manager.add_completed_id(current_observation['id'])
                         else:
                             plog(f'Tried to observe PTR project {block["project_id"]} but pointing check failed')
+                            self.schedule_manager.add_completed_id(current_observation['id'])
 
                     # Catch if there's a bug with the origin. This should never run.
                     else:

--- a/devices/sequencer.py
+++ b/devices/sequencer.py
@@ -1501,9 +1501,9 @@ class Sequencer:
         This function executes an observing block provided by a calendar event.
         """
 
-
-        if (ephem.now() < g_dev['events']['Civil Dusk'] ) or \
-            (g_dev['events']['Civil Dawn']  < ephem.now() < g_dev['events']['Nightly Reset']):
+        if not self.obs.scope_in_manual_mode and \
+            (ephem.now() < g_dev['events']['Civil Dusk'] \
+            or g_dev['events']['Civil Dawn'] < ephem.now() < g_dev['events']['Nightly Reset']):
             plog ("NOT RUNNING PROJECT BLOCK -- IT IS THE DAYTIME!!")
             g_dev["obs"].send_to_user("A project block was rejected as it is during the daytime.")
             return block_specification     #Added wer 20231103
@@ -1667,7 +1667,7 @@ class Sequencer:
                 for exposure in block['project']['exposures']:
 
                     # Check for terminal conditions
-                    if self.schedule_manager.calendar_event_is_active(block['event_id']):
+                    if not self.schedule_manager.calendar_event_is_active(block['event_id']):
                         plog ("Block ended.")
                         g_dev["obs"].send_to_user("Calendar Block Ended. Stopping project run.")
                         self.blockend = None
@@ -6573,7 +6573,7 @@ class Sequencer:
                     plog ("Site bailing out of Centering")
                     return
 
-                if calendar_event_id is not None and self.schedule_manager.calendar_event_is_active(calendar_event_id):
+                if calendar_event_id is not None and not self.schedule_manager.calendar_event_is_active(calendar_event_id):
                     self.obs.send_to_user("Calendar Block Ended. Stopping project run.")
                     plog("Calendar Block Ended. Stopping project run.")
                     self.blockend = None

--- a/devices/sequencer.py
+++ b/devices/sequencer.py
@@ -807,6 +807,7 @@ class Sequencer:
                         self.block_guard = True
                         self.total_sequencer_control= True
 
+                        #breakpoint()
                         # Run the observation
                         SchedulerObservation(observation, self.obs).run()
 
@@ -1175,6 +1176,8 @@ class Sequencer:
         # Protect from manual commands interferring
         self.block_guard = True
         self.total_sequencer_control= True
+
+        #breakpoint()
 
         # Run the project
         observation = json.loads(block_specification['project']['full_lco_observation'])

--- a/devices/sequencer_helpers.py
+++ b/devices/sequencer_helpers.py
@@ -48,7 +48,7 @@ def compute_target_coordinates(target: dict) -> dict:
 
     # Apply proper motion to calculate position at the observation time
     target_observed = target.apply_space_motion(new_obstime=observation_time)
-   
+
     # Return with ra in hours (0 to 24) and dec in degrees (-90 to 90)
     return {'ra': target_observed.ra.hour, 'dec': target_observed.dec.degree}
 
@@ -123,8 +123,9 @@ def pointing_is_ok(block, config) -> bool:
     # If the block comes from the scheduler, it should have already vetted the pointing,
     # so assume the pointing is fine.
     # Even if the scheduler is wrong, let's not override it and risk making the bugs
-    # harder to track. 
+    # harder to track.
     if block.get('origin', 'PTR') == 'LCO':
+        plog('Skipping pointing check for LCO block')
         return pointing_ok
 
     # If a block is identified, check it is in the sky and not in a poor location
@@ -147,4 +148,3 @@ def pointing_is_ok(block, config) -> bool:
         plog("Not running project as it is too low: " + str(alt) + " degrees.")
         pointing_ok = False
     return pointing_ok
-    

--- a/obs.py
+++ b/obs.py
@@ -37,7 +37,9 @@ import argparse
 
 from astropy.io import fits
 from astropy.utils.data import check_download_cache
-from astropy.coordinates import get_sun
+from astropy.coordinates import get_sun, SkyCoord
+from astropy.time import Time
+import astropy.units as u
 
 import bottleneck as bn
 import numpy as np

--- a/obs.py
+++ b/obs.py
@@ -1912,20 +1912,33 @@ class Observatory:
                                 "lowest_acceptable_altitude"
                             ]
                             if mount_altitude < lowest_acceptable_altitude:
-                                plog(
-                                    "Altitude too low! "
-                                    + str(mount_altitude)
-                                    + ". Parking scope for safety!"
-                                )
-                                if not self.devices["mount"].rapid_park_indicator:
-                                    if (
-                                        not self.devices["sequencer"].morn_bias_dark_latch
-                                        and not self.devices["sequencer"].bias_dark_latch
-                                    ):
-                                        self.cancel_all_activity()
-                                    if self.devices["mount"].home_before_park:
-                                        self.devices["mount"].home_command()
-                                    self.devices["mount"].park_command()
+
+                                plog ("previous status while not slewing reports a low altitude")
+                                plog ("waiting for a new mount update to double-check this")
+                                self.devices["mount"].wait_for_mount_update()
+                                self.devices["mount"].get_status()
+                                time.sleep(2)
+                                # Check again
+                                mount_altitude = float(
+                                self.devices["mount"].previous_status["altitude"]
+                            )
+                                if mount_altitude < lowest_acceptable_altitude:
+                                    plog(
+                                        "Altitude too low! "
+                                        + str(mount_altitude)
+                                        + ". Parking scope for safety!"
+                                    )
+                                    
+                                    breakpoint()
+                                    if not self.devices["mount"].rapid_park_indicator:
+                                        if (
+                                            not self.devices["sequencer"].morn_bias_dark_latch
+                                            and not self.devices["sequencer"].bias_dark_latch
+                                        ):
+                                            self.cancel_all_activity()
+                                        if self.devices["mount"].home_before_park:
+                                            self.devices["mount"].home_command()
+                                        self.devices["mount"].park_command()
                         except Exception as e:
                             plog(traceback.format_exc())
                             plog(e)

--- a/obs.py
+++ b/obs.py
@@ -1929,7 +1929,7 @@ class Observatory:
                                         + ". Parking scope for safety!"
                                     )
                                     
-                                    breakpoint()
+                                    
                                     if not self.devices["mount"].rapid_park_indicator:
                                         if (
                                             not self.devices["sequencer"].morn_bias_dark_latch
@@ -2993,7 +2993,7 @@ class Observatory:
                             target_ra = self.devices["mount"].last_ra_requested
                             target_dec = self.devices["mount"].last_dec_requested
 
-                            if self.devices["sequencer"].block_guard and not self.devices["sequencer"].focussing:
+                            if self.devices["sequencer"].block_guard and not self.devices["sequencer"].lco_block and not self.devices["sequencer"].focussing:
                                 target_ra = self.devices["sequencer"].block_ra
                                 target_dec = self.devices["sequencer"].block_dec
 

--- a/obs.py
+++ b/obs.py
@@ -37,7 +37,7 @@ import argparse
 
 from astropy.io import fits
 from astropy.utils.data import check_download_cache
-from astropy.coordinates import get_sun, SkyCoord
+from astropy.coordinates import get_sun, SkyCoord, AltAz
 from astropy.time import Time
 import astropy.units as u
 

--- a/obs.py
+++ b/obs.py
@@ -37,6 +37,7 @@ import argparse
 
 from astropy.io import fits
 from astropy.utils.data import check_download_cache
+from astropy.coordinates import get_sun
 
 import bottleneck as bn
 import numpy as np

--- a/ptr_utility.py
+++ b/ptr_utility.py
@@ -19,7 +19,7 @@ import ephem
 from ptr_config import site_config
 from global_yard import g_dev
 
-from datetime import timezone, timedelta 
+from datetime import timezone, timedelta
 
 DAY_Directory= g_dev['day']
 
@@ -61,18 +61,29 @@ except KeyError:
 
 os.makedirs(plog_path, exist_ok=True)
 
-def plog(*args, loud = True):
+def plog(*args, color=None, loud=True):
     '''
     loud not used, consider adding an optional incoming module
     and error level, also make file format compatible with csv.
     '''
+    print_colors = {
+        'red': '\033[91m',
+        'green': '\033[92m',
+        'yellow': '\033[93m',
+        'blue': '\033[94m',
+        'magenta': '\033[95m',
+        'cyan': '\033[96m',
+        'reset': '\033[0m'
+    }
+    c = print_colors['reset']
+    r = print_colors['reset']
+    if color in print_colors:
+        c = print_colors[color]
 
     try:
-                
         if len(args) == 1 and args[0] in ['.', '>']:
-            print(args[0])
+            print(f'{c}{args[0]}{r}')
             return
-        
         args_to_str = ''
         exposure_report = False
         for item in args:
@@ -86,7 +97,7 @@ def plog(*args, loud = True):
         if args_to_str[:4] == '||  ':
             exposure_report = True
             args_to_str = args_to_str[4:]
-        print(args_to_str)
+        print(f'{c}{args_to_str}{r}')
         if not exposure_report:
             d_t = str(datetime.utcnow()) + ' '
             with open(plog_path + 'nightlog.txt', 'a') as file:

--- a/ptr_utility.py
+++ b/ptr_utility.py
@@ -13,13 +13,13 @@ Conversion constants could be CAP-case as in R2D, R2AS, H2S, etc.
 """
 
 
-from datetime import datetime
 import os
 import ephem
 from ptr_config import site_config
 from global_yard import g_dev
 
-from datetime import timezone, timedelta
+from functools import partial
+from datetime import timezone, timedelta, datetime
 
 DAY_Directory= g_dev['day']
 
@@ -61,50 +61,86 @@ except KeyError:
 
 os.makedirs(plog_path, exist_ok=True)
 
-def plog(*args, color=None, loud=True):
+def plog(*args, color=None, process=None, loud=True):
     '''
-    loud not used, consider adding an optional incoming module
-    and error level, also make file format compatible with csv.
+    Enhanced logging function with color support and module tracking.
+
+    Parameters:
+    - *args: Content to log
+    - color: Text color (red, green, yellow, blue, magenta, cyan)
+    - process: Subprocess name for context
+    - loud: Whether to print to console (default True)
     '''
-    print_colors = {
-        'red': '\033[91m',
-        'green': '\033[92m',
-        'yellow': '\033[93m',
-        'blue': '\033[94m',
-        'magenta': '\033[95m',
-        'cyan': '\033[96m',
-        'reset': '\033[0m'
-    }
-    c = print_colors['reset']
-    r = print_colors['reset']
-    if color in print_colors:
-        c = print_colors[color]
+    # Define reset color code - required at the end of colored strings
+    r = '\033[0m'
+
+    # Handle None color to avoid "None" being printed
+    c = color if color is not None else ''
 
     try:
+        # Special case for progress indicators
         if len(args) == 1 and args[0] in ['.', '>']:
-            print(f'{c}{args[0]}{r}')
+            if loud:
+                print(f'{c}{args[0]}{r}')
             return
+
+        # Convert args to a properly formatted string
         args_to_str = ''
         exposure_report = False
+
         for item in args:
             item_to_string = str(item)
             if item_to_string[-1] == ' ':
                 args_to_str += str(item)
             else:
-                args_to_str += str(item) + ' '  #  Add space between fields
-        args_to_str = args_to_str.strip()   #Eliminate trailing space.
-        # ToDo  Need to strip unnecessary line feeds  '\n'
+                args_to_str += str(item) + ' '  # Add space between fields
+
+        args_to_str = args_to_str.strip()  # Eliminate trailing space
+
+        # Remove unnecessary line feeds
+        args_to_str = args_to_str.replace('\n\n\n', '\n').replace('\n\n', '\n')
+
         if args_to_str[:4] == '||  ':
             exposure_report = True
             args_to_str = args_to_str[4:]
-        print(f'{c}{args_to_str}{r}')
+
+        if loud:
+            if process:
+                print(f"{c}[{process}]{r} {args_to_str}")
+            else:
+                print(f'{args_to_str}')
+
         if not exposure_report:
-            d_t = str(datetime.utcnow()) + ' '
+            d_t = str(datetime.now(timezone.utc)).split('+')[0][:-3] + ' '
+            log_entry = d_t
+
+            # Make CSV-compatible by escaping quotes and enclosing in quotes if needed
+            # Default process is "obs", but only for the logs.
+            log_category = process or "obs"
+            log_entry += f'"{log_category}"'
+
+            # Escape quotes for CSV compatibility
+            csv_safe_args = args_to_str.replace('"', '""')
+            log_entry += f'"{csv_safe_args}"'
+
             with open(plog_path + 'nightlog.txt', 'a') as file:
-                file.write(d_t + " " + args_to_str +'\n')
+                file.write(log_entry + '\n')
+    except Exception as e:
+        print(f"plog failed: {str(e)}")
+        print("Failed to convert to string: ", args)
 
-    except:
-        print("plog failed to convert to string:  ", args)
-
-    #Add logging here.
     return
+
+def create_color_plog(process_id, rgb256=tuple):
+    """
+    Creates a module-specific plog function with predefined module name and color.
+
+    Parameters:
+    - module_name: Name of the module to be logged
+    - default_color: Default color for this module's logs
+
+    Returns:
+    - A customized plog function for this module
+    """
+    rgb = lambda r, g, b: f'\033[38;2;{r};{g};{b}m'
+    return partial(plog, process=process_id, color=rgb(*rgb256))

--- a/subprocesses/Platesolver_SingleImageFullReduction.py
+++ b/subprocesses/Platesolver_SingleImageFullReduction.py
@@ -334,7 +334,7 @@ if len(acatalog) > 5:
 
     os.system('wsl --exec solve-field ' + astoptions + ' ' + str(realwslfilename))
 
-
+#plog (wslfilename)
 # Remove temporary fits file
 try:
     os.remove(wslfilename)

--- a/subprocesses/Platesolver_SingleImageFullReduction.py
+++ b/subprocesses/Platesolver_SingleImageFullReduction.py
@@ -46,11 +46,19 @@ from astropy.stats import sigma_clip
 import subprocess
 from astropy.table import Table
 
+# Add the parent directory to the Python path
+# This allows importing modules from the root directory
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ptr_utility import create_color_plog
+
+log_color = (170, 150, 255) # lavender
+plog = create_color_plog('platesolve', log_color)
+
 def save_xylist(astropy_table, output_filename="xylist.txt"):
     """
     Convert an Astropy Table with X_IMAGE, Y_IMAGE, and FLUX_AUTO columns
     into a whitespace-separated XY list file for Astrometry.net.
-    
+
     Parameters:
     - astropy_table: Astropy Table containing 'X_IMAGE', 'Y_IMAGE', and 'FLUX_AUTO'.
     - output_filename: Name of the output file (default: xylist.txt).
@@ -65,7 +73,7 @@ def save_xylist(astropy_table, output_filename="xylist.txt"):
         for xi, yi, fi in zip(x, y, flux):
             f.write(f"{xi:.6f} {yi:.6f} {fi:.6f}\n")
 
-    print(f"XY list saved as {output_filename}")
+    plog(f"XY list saved as {output_filename}")
 
 def save_sources_as_fits(astropy_table, output_filename="sources.fits"):
     """
@@ -91,8 +99,8 @@ def save_sources_as_fits(astropy_table, output_filename="sources.fits"):
 
     # Save to file
     hdu.writeto(output_filename, overwrite=True)
-    
-    print(f"Sources saved as {output_filename}")
+
+    plog(f"Sources saved as {output_filename}")
 
 input_psolve_info=pickle.load(sys.stdin.buffer)
 #input_psolve_info=pickle.load(open('testplatesolvepickle','rb'))
@@ -119,14 +127,14 @@ googtime=time.time()
 # If this is an osc image, then interpolate so it is just the green filter image of the same size.
 if is_osc:
     ########## Need to split the file into four
-    print ("do osc stuff")
+    plog ("do osc stuff")
 
 
 # Check that the wcs directory is constructed
-#print ("HERE WE ARE")
+#plog ("HERE WE ARE")
 tempwcsdir=filepath.split('wcs')[0] + 'wcs'
-#print (filepath)
-#print (tempwcsdir)
+#plog (filepath)
+#plog (tempwcsdir)
 
 if not os.path.exists(tempwcsdir):
     os.makedirs(tempwcsdir, mode=0o777)
@@ -134,7 +142,7 @@ if not os.path.exists(tempwcsdir):
 # then Check that the individual sequence directory is constructed
 if not os.path.exists(filepath):
     os.makedirs(filepath, mode=0o777)
-    
+
 # then Check that the individual sequence directory is constructed
 tempdir=filepath + '/temp'
 if not os.path.exists(tempdir):
@@ -148,13 +156,13 @@ realwslfilename[0]=realwslfilename[0].lower()
 realwslfilename='/mnt/'+ realwslfilename[0] + realwslfilename[1]
 
 
-print (realwslfilename)
+plog (realwslfilename)
 
 pixlow = 0.97 * pixscale
 pixhigh = 1.03 * pixscale
 initial_radius=2
 
-print ("Just before solving: " +str(time.time()-googtime))
+plog ("Just before solving: " +str(time.time()-googtime))
 
 # Save an image to the disk to use with source-extractor
 # We don't need accurate photometry, so integer is fine.
@@ -180,7 +188,7 @@ fwhmfilename=filepath + '/' + filebase.replace('.fits','.fwhm')
 #      '-CATALOG_NAME', str(tempdir + '/test.cat'), '-SATUR_LEVEL', str(65535), '-GAIN', str(1), '-BACKPHOTO_TYPE','LOCAL', '-DETECT_THRESH', str(1.0), '-ANALYSIS_THRESH',str(1.0),
 #      '-SEEING_FWHM', str(2.0), '-FILTER_NAME', str('photometryparams/sourceex_convs/gauss_2.0_5x5.conv')], stdin=subprocess.PIPE,
 #     stdout=subprocess.PIPE, bufsize=0)
-# tempprocess.wait() 
+# tempprocess.wait()
 
 current_working_directory=os.getcwd()
 cwd_in_wsl=current_working_directory.split(':')
@@ -268,11 +276,11 @@ try:
 
     with open(fwhmfilename, 'wb') as fp:
         pickle.dump(picklefwhm, fp)
-        #print('dictionary saved successfully to file')
+        #plog('dictionary saved successfully to file')
 
 except:
-    print(traceback.format_exc())
-    
+    plog(traceback.format_exc())
+
     picklefwhm["SKYLEVEL"] = (bn.nanmedian(hdufocusdata), "Sky Level without pedestal")
 
     picklefwhm["FWHM"] = (-99, 'FWHM in pixels')
@@ -280,7 +288,7 @@ except:
     picklefwhm["FWHMasec"] = (-99, 'FWHM in arcseconds')
     picklefwhm["FWHMstd"] = ( -99, 'FWHM standard deviation in arcseconds')
     picklefwhm["NSTARS"] = ( len(filtered_fwhm ), 'Number of star-like sources in image')
-    
+
 
 
 with open(fwhmfilename, 'wb') as fp: # os.getcwd() + '/' + file.replace('.fits', '.wcs').replace('.fit', '.fwhm')
@@ -296,7 +304,7 @@ if sizewidest > 1.0:
     tweakorder=[3,2]
 else:
     tweakorder=[2,3]
-    
+
 
 #os.system('wsl --exec mkdir /home/obs/wcstempfiles')
 #os.system('ls ' + str(tempdir_in_wsl))
@@ -304,12 +312,12 @@ else:
 
 #save_xylist(acatalog, tempdir + '/test' + str(nextseq) + '.txt')
 
-#print ('cp ' + str(tempdir_in_wsl + '/test.fits /home/obs/wcstempfiles/test' + str(nextseq) + '.fits'))
+#plog ('cp ' + str(tempdir_in_wsl + '/test.fits /home/obs/wcstempfiles/test' + str(nextseq) + '.fits'))
 
-#astoptions = 
-#print ("wsl --exec solve-field /home/obs/wcstempfiles/test" + str(nextseq) + '.fits' +" -D /home/obs/wcstempfiles --x-column X_IMAGE --y-column Y_IMAGE --sort-column FLUX_AUTO --crpix-center --tweak-order " +str (tweakorder[0]) + " --width " +str(imagew) +" --height " +str(imageh) +" --scale-units arcsecperpix --scale-low " + str(pixlow) + " --scale-high " + str(pixhigh) + " --scale-units arcsecperpix --ra " + str(RAest) + " --dec " + str(DECest) + " --radius 10 --cpulimit 300 --depth 1-100 --overwrite --no-verify --no-plots " )
+#astoptions =
+#plog ("wsl --exec solve-field /home/obs/wcstempfiles/test" + str(nextseq) + '.fits' +" -D /home/obs/wcstempfiles --x-column X_IMAGE --y-column Y_IMAGE --sort-column FLUX_AUTO --crpix-center --tweak-order " +str (tweakorder[0]) + " --width " +str(imagew) +" --height " +str(imageh) +" --scale-units arcsecperpix --scale-low " + str(pixlow) + " --scale-high " + str(pixhigh) + " --scale-units arcsecperpix --ra " + str(RAest) + " --dec " + str(DECest) + " --radius 10 --cpulimit 300 --depth 1-100 --overwrite --no-verify --no-plots " )
 
-# Try once with tweak-order 2   
+# Try once with tweak-order 2
 #os.system("/usr/local/astrometry/bin/solve-field -D " + str(tempdir) + " --use-source-extractor --crpix-center --tweak-order " +str (tweakorder[0]) + " --width " +str(imagew) +" --height " +str(imageh) +" --scale-units arcsecperpix --scale-low " + str(pixlow) + " --scale-high " + str(pixhigh) + " --scale-units arcsecperpix --ra " + str(RAest) + " --dec " + str(DECest) + " --radius 10 --cpulimit 90 --depth 1-100 --overwrite --no-verify --no-plots " + str(wslfilename))
 #os.system("wsl --exec solve-field  /home/obs/wcstempfiles/test" + str(nextseq) + '.fits' +" -D /home/obs/wcstempfiles --x-column X_IMAGE --y-column Y_IMAGE --sort-column FLUX_AUTO --crpix-center --tweak-order " +str (tweakorder[0]) + " --width " +str(imagew) +" --height " +str(imageh) +" --scale-units arcsecperpix --scale-low " + str(pixlow) + " --scale-high " + str(pixhigh) + " --scale-units arcsecperpix --ra " + str(RAest) + " --dec " + str(DECest) + " --radius 10 --cpulimit 300 --depth 1-100 --overwrite --no-verify --no-plots --skip-solve" )
 #os.system("/usr/bin/astrometry-engine /home/obs/wcstempfiles/test" + str(nextseq) + '.axy')
@@ -322,7 +330,7 @@ else:
 if len(acatalog) > 5:
     astoptions = '--crpix-center --tweak-order 2 --use-source-extractor --scale-units arcsecperpix --scale-low ' + str(pixlow) + ' --scale-high ' + str(pixhigh) + ' --ra ' + str(RAest) + ' --dec ' + str(DECest) + ' --radius 20 --cpulimit ' +str(cpu_limit * 3) + ' --overwrite --no-verify --no-plots'
 
-    print (astoptions)
+    plog (astoptions)
 
     os.system('wsl --exec solve-field ' + astoptions + ' ' + str(realwslfilename))
 
@@ -337,36 +345,36 @@ sys.exit()
 #breakpoint()
 
 if os.path.exists(tempdir + '/test.wcs'):
-    print("A successful solve for " + wslfilename)
+    plog("A successful solve for " + wslfilename)
     # os.remove(wslfilename)
     # shutil.move(tempdir + '/test.wcs', os.getcwd() + '/' + wslfilename.replace('.fits', '.wcs').replace('.fit', '.wcs'))
 # os.remove(file)
 else:
-    # Try once with tweak-order 3    
+    # Try once with tweak-order 3
     os.system("wsl --exec solve-field /home/obs/wcstempfiles/test" + str(nextseq) + '.fits' +" -D /home/obs/wcstempfiles --x-column X_IMAGE --y-column Y_IMAGE --sort-column FLUX_AUTO --crpix-center --tweak-order " +str (tweakorder[1]) + " --width " +str(imagew) +" --height " +str(imageh) +" --scale-units arcsecperpix --scale-low " + str(pixlow) + " --scale-high " + str(pixhigh) + " --scale-units arcsecperpix --ra " + str(RAest) + " --dec " + str(DECest) + " --radius 10 --cpulimit 300 --depth 1-100 --overwrite --no-verify --no-plots " )
     os.system("/usr/bin/astrometry-engine /home/obs/wcstempfiles/test" + str(nextseq) + '.axy')
 
     if os.path.exists(tempdir + '/test.wcs'):
-        print("A successful solve for " + wslfilename)
+        plog("A successful solve for " + wslfilename)
         # os.remove(wslfilename)
         # shutil.move(tempdir + '/test.wcs', os.getcwd() + '/' + wslfilename.replace('.fits', '.wcs').replace('.fit', '.wcs'))
     # os.remove(file)
     else:
-        # Try once with tweak-order 4    
+        # Try once with tweak-order 4
         os.system("wsl --exec solve-field /home/obs/wcstempfiles/test" + str(nextseq) + '.fits' +" -D /home/obs/wcstempfiles --x-column X_IMAGE --y-column Y_IMAGE --sort-column FLUX_AUTO --crpix-center --tweak-order " +str (4) + " --width " +str(imagew) +" --height " +str(imageh) +" --scale-units arcsecperpix --scale-low " + str(pixlow) + " --scale-high " + str(pixhigh) + " --scale-units arcsecperpix --ra " + str(RAest) + " --dec " + str(DECest) + " --radius 10 --cpulimit 300 --depth 1-100 --overwrite --no-verify --no-plots " )
         os.system("/usr/bin/astrometry-engine /home/obs/wcstempfiles/test" + str(nextseq) + '.axy')
 
         if os.path.exists(tempdir + '/test.wcs'):
-            print("A successful solve for " + wslfilename)
+            plog("A successful solve for " + wslfilename)
             # os.remove(wslfilename)
             # shutil.move(tempdir + '/test.wcs', os.getcwd() + '/' + wslfilename.replace('.fits', '.wcs').replace('.fit', '.wcs'))
         # os.remove(file)
         else:
-            
-                       
-            print("A failed solve for " + wslfilename)
+
+
+            plog("A failed solve for " + wslfilename)
             # os.remove(wslfilename)
-                
+
 
 
 
@@ -390,13 +398,13 @@ else:
 
 # #astoptions = '--crpix-center --tweak-order 2 --use-source-extractor --scale-units arcsecperpix --scale-low ' + str(low_pixscale) + ' --scale-high ' + str(high_pixscale) + ' --ra ' + str(pointing_ra * 15) + ' --dec ' + str(pointing_dec) + ' --radius ' + str(initial_radius) + ' --cpulimit ' +str(cpu_limit) + ' --overwrite --no-verify --no-plots'
 
-# print (astoptions)
+# plog (astoptions)
 
 # os.system('wsl --exec solve-field ' + astoptions + ' ' + str(realwslfilename))
 
 # # If successful, then a file of the same name but ending in solved exists.
 # if os.path.exists(wslfilename.replace('.fits','.wcs')):
-#     print ("IT EXISTS! WCS SUCCESSFUL!")
+#     plog ("IT EXISTS! WCS SUCCESSFUL!")
 #     wcs_header=fits.open(wslfilename.replace('.fits','.wcs'))[0].header
 #     solve={}
 #     solve["ra_j2000_hours"] = wcs_header['CRVAL1']/15
@@ -413,7 +421,7 @@ else:
 
 # else:
 
-#     print ("FAILED NORMAL, TRYING HAIL MARY ATTEMPT")
+#     plog ("FAILED NORMAL, TRYING HAIL MARY ATTEMPT")
 #     # Remove the previous attempt which was just a table fits
 #     temp_files_to_remove=glob.glob(cal_path + 'wsltemp*')
 #     for f in temp_files_to_remove:
@@ -426,13 +434,13 @@ else:
 
 #     astoptions = '--crpix-center --tweak-order 2 --use-source-extractor --scale-units arcsecperpix --scale-low ' + str(low_pixscale) + ' --scale-high ' + str(high_pixscale) + ' --ra ' + str(pointing_ra * 15) + ' --dec ' + str(pointing_dec) + ' --radius 20 --cpulimit ' +str(cpu_limit * 3) + ' --overwrite --no-verify --no-plots'
 
-#     print (astoptions)
+#     plog (astoptions)
 
 #     os.system('wsl --exec solve-field ' + astoptions + ' ' + str(realwslfilename))
 
 #     # If successful, then a file of the same name but ending in solved exists.
 #     if os.path.exists(wslfilename.replace('.fits','.wcs')):
-#         print ("IT EXISTS! WCS SUCCESSFUL!")
+#         plog ("IT EXISTS! WCS SUCCESSFUL!")
 #         wcs_header=fits.open(wslfilename.replace('.fits','.wcs'))[0].header
 #         solve={}
 #         solve["ra_j2000_hours"] = wcs_header['CRVAL1']/15
@@ -447,7 +455,7 @@ else:
 
 #         solve["arcsec_per_pixel"]  = solve["arcsec_per_pixel"][0]
 
-        
+
 #     else:
 #         solve = 'error'
 
@@ -457,6 +465,6 @@ else:
 
 
 
-# print (solve)
-# print ("solver: " +str(time.time()-googtime))
+# plog (solve)
+# plog ("solver: " +str(time.time()-googtime))
 

--- a/subprocesses/SEPprocess.py
+++ b/subprocesses/SEPprocess.py
@@ -11,6 +11,7 @@ import numpy as np
 import bottleneck as bn
 # Need this line to output the full array to text for the json
 np.set_printoptions(threshold=np.inf)
+import builtins
 import re
 from astropy.stats import median_absolute_deviation
 from astropy.nddata.utils import extract_array
@@ -39,7 +40,14 @@ warnings.simplefilter("ignore", category=RuntimeWarning)
 #import matplotlib.pyplot as plt
 from scipy.stats import binned_statistic
 
-#print("Starting sep_process.py")
+def print(*args):
+    rgb = lambda r, g, b: f'\033[38;2;{r};{g};{b}m'
+    log_color = (255, 130, 200) # pink
+    c = rgb(*log_color)
+    r = '\033[0m' # reset
+    builtins.print(f"{c}[sep]{r} {' '.join([str(x) for x in args])}")
+
+print("Starting sep_process.py")
 
 
 def gaussian(x, amplitude, mean, stddev):

--- a/subprocesses/SmartStackprocess.py
+++ b/subprocesses/SmartStackprocess.py
@@ -23,11 +23,20 @@ from math import sqrt
 import traceback
 import copy
 
+# Add the parent directory to the Python path
+# This allows importing modules from the root directory
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ptr_utility import create_color_plog
+
+log_color = (50,200,50) # bright green
+plog = create_color_plog('sstk', log_color)
+
+
 input_sstk_info = pickle.load(sys.stdin.buffer)
 # input_sstk_info=pickle.load(open('testsmartstackpickle','rb'))
 
-print("Starting SmartStackprocess.py")
-print(input_sstk_info)
+plog("Starting SmartStackprocess.py")
+plog(input_sstk_info)
 
 
 smartstackthread_filename=input_sstk_info[0]
@@ -74,7 +83,7 @@ while (not os.path.exists(smartstackthread_filename)) and (time.time()-file_wait
 
 if time.time()-file_wait_timeout_timer > 599:
     sys.exit()
-    
+
 (image_filename, imageMode) = pickle.load(
     open(smartstackthread_filename, 'rb'))
 
@@ -145,7 +154,7 @@ if not os.path.exists(jpeg_path + smartstackid + '.busy'):
             ):
                 if True:
 
-                    print ("Storing single original image")
+                    plog ("Storing single original image")
 
                     # Store original image
                     np.save(
@@ -157,7 +166,7 @@ if not os.path.exists(jpeg_path + smartstackid + '.busy'):
                     try:
                         os.remove(jpeg_path + smartstackid + '.busy')
                     except:
-                        print ("COULDNT DELETE BUSY TOKEN! ALERT!")
+                        plog ("COULDNT DELETE BUSY TOKEN! ALERT!")
 
                 else:
                     reprojection_failed = True
@@ -175,10 +184,10 @@ if not os.path.exists(jpeg_path + smartstackid + '.busy'):
                 googtime=time.time()
                 edge_crop=100
                 xoff, yoff = cross_correlation_shifts(block_reduce(de_nanned_reference_frame[edge_crop:-edge_crop,edge_crop:-edge_crop],3, func=np.nanmean), block_reduce(tempnan[edge_crop:-edge_crop,edge_crop:-edge_crop],3, func=np.nanmean),zeromean=False)
-                print (time.time()-googtime)
-                print ("3x")
-                print (str(-yoff*3) + " " + str(-xoff*3))
-                print (str(round(-yoff*3)) + " " + str(round(-xoff*3)))
+                plog (time.time()-googtime)
+                plog ("3x")
+                plog (str(-yoff*3) + " " + str(-xoff*3))
+                plog (str(round(-yoff*3)) + " " + str(round(-xoff*3)))
                 imageshift=[round(-yoff*3),round(-xoff*3)]
 
                 if abs(imageshift[0]) > 0:
@@ -211,7 +220,7 @@ if not os.path.exists(jpeg_path + smartstackid + '.busy'):
                 try:
                     os.remove(jpeg_path + smartstackid + '.busy')
                 except:
-                    print("COULDNT DELETE BUSY TOKEN! ALERT!")
+                    plog("COULDNT DELETE BUSY TOKEN! ALERT!")
 
         if reprojection_failed == True:  # If we couldn't make a stack send a jpeg of the original image.
             storedsStack = imgdata
@@ -270,7 +279,7 @@ if not os.path.exists(jpeg_path + smartstackid + '.busy'):
                   'temp.jpg'), jpeg_path + jpeg_name.replace('EX10', 'EX20'))
         # Resizing the array to an appropriate shape for the jpg and the small fits
         # insert Debify routine here.  NB NB Note LCO '30-amin Sq field not implemented.'
-        print('Zoom factor is:  ', zoom_factor)
+        plog('Zoom factor is:  ', zoom_factor)
         if zoom_factor is not False:
             if zoom_factor in ['full', 'Full', '100%']:
                 zoom = (0.0, 0.0, 0.0, 0.0)  # Trim nothing
@@ -310,7 +319,7 @@ if not os.path.exists(jpeg_path + smartstackid + '.busy'):
             yb *= iy
             trial_image = final_image.crop((int(xl), int(yt), int(ix-xr), int(iy-yb)))
             ix, iy = trial_image.size
-            print("Zoomed Image size:", ix, iy)
+            plog("Zoomed Image size:", ix, iy)
             final_image = trial_image
         if iy == ix:
             final_image = final_image.resize(
@@ -419,33 +428,33 @@ if not os.path.exists(jpeg_path + smartstackid + '.busy'):
                     crosscorrel_filename_waiter.append(
                         obsid_path + "smartstacks/" + output_filename)
 
-                    #print (crosscorrelation_subprocess_array)
+                    #plog (crosscorrelation_subprocess_array)
 
                     crosscorrelation_subprocess_array.append(
                         subprocess.Popen(
-                            ['python', 'subprocesses/crosscorrelation_subprocess.py'], 
-                            stdin=subprocess.PIPE, 
-                            stdout=None, 
+                            ['python', 'subprocesses/crosscorrelation_subprocess.py'],
+                            stdin=subprocess.PIPE,
+                            stdout=None,
                             bufsize=-1
                         )
                     )
-                    #print(counter)
-                    #print (crosscorrelation_subprocess_array[counter])
+                    #plog(counter)
+                    #plog (crosscorrelation_subprocess_array[counter])
                     pickle.dump(pickler, crosscorrelation_subprocess_array[counter].stdin)
                     crosscorrelation_subprocess_array[counter].stdin.flush()
                     counter=counter+1
 
             # Wait for the three crosscorrels to happen
             for waitfile in crosscorrel_filename_waiter:
-                
-                file_wait_timeout_timer=time.time()                
-                    
+
+                file_wait_timeout_timer=time.time()
+
                 while (not os.path.exists(waitfile)) and (time.time()-file_wait_timeout_timer < 600):
                     time.sleep(0.2)
-                    
+
                 if time.time()-file_wait_timeout_timer > 599:
                     sys.exit()
-                    
+
             if len(crosscorrel_filename_waiter) > 0:
                 for waitfile in crosscorrel_filename_waiter:
 
@@ -488,7 +497,7 @@ if not os.path.exists(jpeg_path + smartstackid + '.busy'):
             try:
                 os.remove(jpeg_path + smartstackid + '.busy')
             except:
-                print("COULDNT DELETE BUSY TOKEN! ALERT!")
+                plog("COULDNT DELETE BUSY TOKEN! ALERT!")
 
             pickle.dump(reprojection_failed, open(jpeg_path + 'smartstack.pickle', 'wb'))
 
@@ -586,7 +595,7 @@ if not os.path.exists(jpeg_path + smartstackid + '.busy'):
 
             # Resizing the array to an appropriate shape for the small jpg
             ix, iy = final_image.size
-            print('Zoom factor is:  ', zoom_factor)
+            plog('Zoom factor is:  ', zoom_factor)
             if zoom_factor is not False:
                 if zoom_factor in ['full', 'Full', '100%']:
                     zoom = (0.0, 0.0, 0.0, 0.0)  # Trim nothing
@@ -633,7 +642,7 @@ if not os.path.exists(jpeg_path + smartstackid + '.busy'):
                 yb *= iy
                 trial_image=final_image.crop((int(xl),int(yt),int(ix-xr),int(iy-yb)))
                 ix, iy = trial_image.size
-                print("Zoomed Image size:", ix, iy)
+                plog("Zoomed Image size:", ix, iy)
                 final_image = trial_image
 
             iy, ix = final_image.size

--- a/subprocesses/crosscorrelation_subprocess.py
+++ b/subprocesses/crosscorrelation_subprocess.py
@@ -17,7 +17,15 @@ import bottleneck as bn
 #from astropy.stats import sigma_clip
 from joblib import Parallel, delayed
 
-#print("Starting crosscorrelation_subprocess.py")
+# Add the parent directory to the Python path
+# This allows importing modules from the root directory
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ptr_utility import create_color_plog
+
+log_color = (0,180, 160) # teal
+plog = create_color_plog('crosscor', log_color)
+
+plog("Starting crosscorrelation_subprocess.py")
 
 payload=pickle.load(sys.stdin.buffer)
 #payload=pickle.load(open('crosscorrelprocess.pickle','rb'))
@@ -285,7 +293,7 @@ try:
             imageshiftsign = -1
         substackimage=np.roll(substackimage, imageshiftabs*imageshiftsign, axis=1)
 except:
-    print(traceback.format_exc())
+    plog(traceback.format_exc())
 
 try:
     os.remove(temporary_substack_directory + output_filename +'temp')

--- a/subprocesses/fz_archive_file.py
+++ b/subprocesses/fz_archive_file.py
@@ -34,7 +34,7 @@ def print(*args):
     builtins.print(f"{c}[fz_archive]{r} {' '.join([str(x) for x in args])}")
 
 print("Starting fz_archive_file.py")
-print(input_sep_info)
+# print(input_sep_info)
 
 
 temphduheader=input_sep_info[0]

--- a/subprocesses/fz_archive_file.py
+++ b/subprocesses/fz_archive_file.py
@@ -14,7 +14,7 @@ import sys
 import pickle
 import os
 import time
-#import traceback
+import builtins
 from astropy.io import fits
 from astropy.nddata import block_reduce
 from astropy.utils.exceptions import AstropyUserWarning
@@ -26,8 +26,15 @@ import bottleneck as bn
 #input_sep_info=pickle.load(open('testfz1714133591386061','rb'))
 input_sep_info=pickle.load(open(sys.argv[1],'rb'))
 
-#print ("Starting fz_archive_file.py")
-#print (input_sep_info)
+def print(*args):
+    rgb = lambda r, g, b: f'\033[38;2;{r};{g};{b}m'
+    log_color = (240, 200, 90) # gold
+    c = rgb(*log_color)
+    r = '\033[0m' # reset
+    builtins.print(f"{c}[fz_archive]{r} {' '.join([str(x) for x in args])}")
+
+print("Starting fz_archive_file.py")
+print(input_sep_info)
 
 
 temphduheader=input_sep_info[0]

--- a/subprocesses/local_reduce_file_subprocess.py
+++ b/subprocesses/local_reduce_file_subprocess.py
@@ -32,8 +32,8 @@ def print(*args):
 #input_sep_info=pickle.load(open('testfz17141141966139522','rb'))
 input_sep_info=pickle.load(open(sys.argv[1],'rb'))
 
-print("Starting local_reduce_file_subprocess.py")
-print(input_sep_info)
+#print("Starting local_reduce_file_subprocess.py")
+#print(input_sep_info)
 
 temphduheader=input_sep_info[0]
 selfconfig=input_sep_info[1]

--- a/subprocesses/local_reduce_file_subprocess.py
+++ b/subprocesses/local_reduce_file_subprocess.py
@@ -9,6 +9,7 @@ This is called from SmartStackProcess.py when it is running an OSC stack.
 As it is a relatively expensive (in time) operation, they need to run in parallel.
 """
 
+import builtins
 import numpy as np
 import sys
 import pickle
@@ -20,28 +21,19 @@ import warnings
 import datetime
 warnings.simplefilter('ignore', category=AstropyUserWarning)
 
-# Add the parent directory to the Python path
-# This allows importing modules from the root directory
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname((os.path.abspath(__file__)))))))
-# Add the root directory to the Python path
-root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if root_dir not in sys.path:
-    sys.path.insert(0, root_dir)
-print('SYSTEM PATH FROM LOCAL_REDUCE_FILE_SUBPROCESS.PY')
-print(sys.path)
-from ptr_utility import create_color_plog
-
-log_color = (0, 210, 210) # cyan
-plog = create_color_plog('reduce', log_color)
+def print(*args):
+    rgb = lambda r, g, b: f'\033[38;2;{r};{g};{b}m'
+    log_color = (0, 210, 210) # cyan
+    c = rgb(*log_color)
+    r = '\033[0m' # reset
+    builtins.print(f"{c}[sep]{r} {' '.join([str(x) for x in args])}")
 
 #input_sep_info=pickle.load(sys.stdin.buffer)
 #input_sep_info=pickle.load(open('testfz17141141966139522','rb'))
 input_sep_info=pickle.load(open(sys.argv[1],'rb'))
 
-plog("Starting local_reduce_file_subprocess.py")
-plog(input_sep_info)
+print("Starting local_reduce_file_subprocess.py")
+print(input_sep_info)
 
 temphduheader=input_sep_info[0]
 selfconfig=input_sep_info[1]

--- a/subprocesses/local_reduce_file_subprocess.py
+++ b/subprocesses/local_reduce_file_subprocess.py
@@ -20,12 +20,28 @@ import warnings
 import datetime
 warnings.simplefilter('ignore', category=AstropyUserWarning)
 
+# Add the parent directory to the Python path
+# This allows importing modules from the root directory
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname((os.path.abspath(__file__)))))))
+# Add the root directory to the Python path
+root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if root_dir not in sys.path:
+    sys.path.insert(0, root_dir)
+print('SYSTEM PATH FROM LOCAL_REDUCE_FILE_SUBPROCESS.PY')
+print(sys.path)
+from ptr_utility import create_color_plog
+
+log_color = (0, 210, 210) # cyan
+plog = create_color_plog('reduce', log_color)
+
 #input_sep_info=pickle.load(sys.stdin.buffer)
 #input_sep_info=pickle.load(open('testfz17141141966139522','rb'))
 input_sep_info=pickle.load(open(sys.argv[1],'rb'))
 
-#print ("Starting local_reduce_file_subprocess.py")
-#print (input_sep_info)
+plog("Starting local_reduce_file_subprocess.py")
+plog(input_sep_info)
 
 temphduheader=input_sep_info[0]
 selfconfig=input_sep_info[1]
@@ -79,7 +95,7 @@ while (breaker != 0):
                                                         if not (imageMode-counter-13) in zeroValueArray[:,0]:
                                                             if not (imageMode-counter-14) in zeroValueArray[:,0]:
                                                                 if not (imageMode-counter-15) in zeroValueArray[:,0]:
-                                                                    if not (imageMode-counter-16) in zeroValueArray[:,0]: 
+                                                                    if not (imageMode-counter-16) in zeroValueArray[:,0]:
                                                                         zeroValue=(imageMode-counter)
                                                                         breaker =0
 
@@ -154,7 +170,7 @@ hdureduced.writeto(
     slow_process[1], overwrite=True, output_verify='silentfix'
 )  # Save flash reduced file locally
 
-if selfconfig["save_to_alt_path"] == "yes":  
+if selfconfig["save_to_alt_path"] == "yes":
     hdureduced.writeto( selfconfig['alt_path'] +'/' +temphduheader['OBSID'] +'/' +temphduheader['DAY-OBS'] + "/reduced/" + slow_process[1].split('/')[-1].replace('EX00','EX00-'+temphduheader['OBSTYPE']), overwrite=True, output_verify='silentfix'
     )  # Save full raw file locally
 

--- a/subprocesses/mainjpeg.py
+++ b/subprocesses/mainjpeg.py
@@ -15,6 +15,14 @@ import warnings
 warnings.simplefilter('ignore', category=AstropyUserWarning)
 warnings.simplefilter("ignore", category=RuntimeWarning)
 
+# Add the parent directory to the Python path
+# This allows importing modules from the root directory
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ptr_utility import create_color_plog
+
+log_color = (120, 220, 170) # mint
+plog = create_color_plog('mainjpg', log_color)
+
 # Pick up the pickled array
 debug = False
 if not debug:
@@ -24,8 +32,8 @@ else:
     #NB Use this input file for debugging this code.
     #input_jpeg_info=pickle.load(open('C:\\Users\\user\\Documents\\GitHub\\ptr-observatory\\testjpegpickle','rb'))
     input_jpeg_info=pickle.load(open('../testjpegpickle','rb'))
-    print("Starting mainjpeg.py")
-    print(input_jpeg_info)
+    plog("Starting mainjpeg.py")
+    plog(input_jpeg_info)
 
 
 mainjpegthread_filename=input_jpeg_info[0]
@@ -54,19 +62,19 @@ xr=input_jpeg_info[22]
 squash_on_x_axis=input_jpeg_info[23]
 #try:
 zoom_factor = input_jpeg_info[24].lower()
-#     print("Mainjpeg received:", zoom_factor)
+#     plog("Mainjpeg received:", zoom_factor)
 # except:
-#     print("Zoom_factor paramater faulted.")
+#     plog("Zoom_factor paramater faulted.")
 jpeg_path = input_jpeg_info[25]
 jpeg_name = input_jpeg_info[26]
 
 
 
 # This process is set to spin up early, so it loads
-# and waits for a filename token to get started.    
+# and waits for a filename token to get started.
 file_wait_timeout_timer=time.time()
-while (not os.path.exists(mainjpegthread_filename)) and (time.time()-file_wait_timeout_timer < 600):    
-    time.sleep(0.2)    
+while (not os.path.exists(mainjpegthread_filename)) and (time.time()-file_wait_timeout_timer < 600):
+    time.sleep(0.2)
 if time.time()-file_wait_timeout_timer > 599:
     sys.exit()
 
@@ -85,7 +93,7 @@ if is_osc:
             hdublue = hdusmalldata[1::2, 1::2]
 
     else:
-        print("this bayer grid not implemented yet")
+        plog("this bayer grid not implemented yet")
 
 # Code to stretch the image to fit into the 256 levels of grey for a jpeg
 # But only if it isn't a smartstack, if so wait for the reduce queue
@@ -197,7 +205,7 @@ if smartstackid == 'no':
             jpeg_path + jpeg_name.replace('EX10', 'EX20')
             #paths["im_path"] + paths['jpeg_name10'].replace('EX10', 'EX20')
         )
-        
+
         # Resizing the array to an appropriate shape for the small jpg
         #iy, ix = final_image.size
         ix, iy = final_image.size
@@ -205,7 +213,7 @@ if smartstackid == 'no':
             final_image=final_image.crop((xl,yt,iy-xr,ix-yb))
             iy, ix = final_image.size
             #insert Debify routine here.  NB NB Note LCO '30-amin Sq field not implemented.'
-        print('Zoom factor is:  ', zoom_factor)
+        plog('Zoom factor is:  ', zoom_factor)
         if zoom_factor is not False:
             if zoom_factor in ['full', 'Full', '100%']:
                 zoom = (0.0, 0.0, 0.0, 0.0)   #  Trim nothing
@@ -244,9 +252,9 @@ if smartstackid == 'no':
             yb *= iy
             trial_image=final_image.crop((int(xl),int(yt),int(ix-xr),int(iy-yb)))
             ix, iy = trial_image.size
-            print("Zoomed Image size:", ix, iy)
+            plog("Zoomed Image size:", ix, iy)
             final_image = trial_image
-            
+
         iy, ix = final_image.size
         if ix == iy:
             final_image = final_image.resize((900, 900))
@@ -304,10 +312,10 @@ if smartstackid == 'no':
         final_image.save(
             jpeg_path + jpeg_name.replace('EX10', 'EX20')
         )
-        
+
         # Resizing the array to an appropriate shape for the jpg and the small fits
         ix, iy = final_image.size
-        print('Zoom factor is:  ', zoom_factor)
+        plog('Zoom factor is:  ', zoom_factor)
         if zoom_factor is not False:
             if zoom_factor in ['full', 'Full', '100%']:
                 zoom = (0.0, 0.0, 0.0, 0.0)   #  Trim nothing
@@ -346,7 +354,7 @@ if smartstackid == 'no':
             yb *= iy
             trial_image=final_image.crop((int(xl),int(yt),int(ix-xr),int(iy-yb)))
             ix, iy = trial_image.size
-            print("Zoomed Image size:", ix, iy)
+            plog("Zoomed Image size:", ix, iy)
             final_image = trial_image
 
         if iy == ix:


### PR DESCRIPTION
This change was motivated by a need for PTR sites to keep track of schedules from the LCO scheduler alongside existing PTR calendar events/projects. It introduces a class called NightlyScheduleManager which is instantiated in sequencer.py.

Features:
- check for new schedules from the PTR calendar and the LCO scheduler (via the site-proxy) if applicable
- updates happen at regular intervals (default 30s; easily configured) in separate threads
- updates can also be manually triggered
- you can mark events as completed
- get events that should run now

Simple usage:
```python
manager = NightlyScheduleManager("mrc1", schedule_start, schedule_end) 

manager.get_observation_to_run_now() # returns the current project, or None
manager.add_completed_id(event_id) # marks this event as completed, and will ignore it from now on

manager.schedule # returns a list of all events scheduled between the configured start/end times
manager.events_happening_now # returns a list of events that are in between the start/end times (usually this will just be a single event)
manager.update_now() # immediately query for updates from PTR and LCO
manager.reset(start, end) # to be used with the nightly reset: clears schedules and completed events list, restarts the start/end times, and starts polling again

# boolean attributes
manager.check_is_completed(event_id) # whether we've marked this as complete or not
manager.calendar_event_is_active(event_id) # whether the event is still currently scheduled
manager.schedule_is_empty 

# In case you want to stop/start the background polling
manager.start_update_threads()
manager.stop_update_threads()
```

This new class gives us more direct access to the scheduler output (reducing a lot of intermediary AWS code), and makes many areas of the observatory code simpler and more readable.


----

Also added colored identifiers to the logging output of the various subprocess modules so they're easier to understand.